### PR TITLE
Filter unique method references

### DIFF
--- a/src/main/java/org/axonframework/intellij/ide/plugin/publisher/DefaultEventPublisherProvider.java
+++ b/src/main/java/org/axonframework/intellij/ide/plugin/publisher/DefaultEventPublisherProvider.java
@@ -37,8 +37,11 @@ class DefaultEventPublisherProvider implements EventPublisherProvider {
         cleanClosedProjects();
         Set<PsiMethod> psiMethods = publisherMethodsPerProject.get(project);
         if (psiMethods == null) {
-            psiMethods = new HashSet<PsiMethod>();
-            publisherMethodsPerProject.put(project, psiMethods);
+            final Set<PsiMethod> newHashSet = new HashSet<PsiMethod>();
+            psiMethods = publisherMethodsPerProject.putIfAbsent(project, newHashSet);
+            if (psiMethods == null) {
+                psiMethods = newHashSet;
+            }
         }
         psiMethods.addAll(findMethods(project, GlobalSearchScope.allScope(project),
                 "org.axonframework.eventsourcing.AbstractEventSourcedAggregateRoot", "apply"));

--- a/src/main/java/org/axonframework/intellij/ide/plugin/publisher/DefaultEventPublisherProvider.java
+++ b/src/main/java/org/axonframework/intellij/ide/plugin/publisher/DefaultEventPublisherProvider.java
@@ -35,14 +35,8 @@ class DefaultEventPublisherProvider implements EventPublisherProvider {
     @Override
     public void scanPublishers(final Project project, GlobalSearchScope scope, final Registrar registrar) {
         cleanClosedProjects();
+        publisherMethodsPerProject.putIfAbsent(project, new HashSet<PsiMethod>());
         Set<PsiMethod> psiMethods = publisherMethodsPerProject.get(project);
-        if (psiMethods == null) {
-            final Set<PsiMethod> newHashSet = new HashSet<PsiMethod>();
-            psiMethods = publisherMethodsPerProject.putIfAbsent(project, newHashSet);
-            if (psiMethods == null) {
-                psiMethods = newHashSet;
-            }
-        }
         psiMethods.addAll(findMethods(project, GlobalSearchScope.allScope(project),
                 "org.axonframework.eventsourcing.AbstractEventSourcedAggregateRoot", "apply"));
         psiMethods.addAll(findMethods(project, GlobalSearchScope.allScope(project),


### PR DESCRIPTION
Previously List was used to store found method references. This caused
the algorithm to perform reduntant search. Changing List to HashSet can
improve performance significantly on a larger project.