### PR TITLE
Fix wrong icon being shown for Publishers in popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # Axon Framework plugin Changelog
 
+## [unreleased]
+
+### Changed
+
+- Query handlers are more easily identifiable in line marker popup
+
 ## [0.5.1]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,16 @@
 
 # Axon Framework plugin Changelog
 
-## [unreleased]
-
-### Changed
-
-- Query handlers are more easily identifiable in line marker popup
-
 ## [0.5.1]
 
 ### Fixed
 
 - Fix popup on deadline manager methods when there are qualified references as arguments. Fixes #16
+- The correct icon is now shown for publishers in line marker popup. Fixes #18
+
+### Changed
+
+- Query handlers are more easily identifiable in line marker popup
 
 ## [0.5.0]
 

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/creators/DefaultMessageCreator.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/creators/DefaultMessageCreator.kt
@@ -41,9 +41,6 @@ data class DefaultMessageCreator(
      * Returns the correct icon for the creator
      */
     override fun getIcon(): Icon {
-        if (parentHandler != null) {
-            return parentHandler.getIcon()
-        }
         return AxonIcons.Publisher
     }
 

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/types/QueryHandler.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/types/QueryHandler.kt
@@ -19,6 +19,7 @@ package org.axonframework.intellij.ide.plugin.resolving.handlers.types
 import com.intellij.psi.PsiMethod
 import org.axonframework.intellij.ide.plugin.api.Handler
 import org.axonframework.intellij.ide.plugin.api.MessageHandlerType
+import org.axonframework.intellij.ide.plugin.util.containingClassname
 
 /**
  * Represents a method being able to handle a query.
@@ -34,6 +35,10 @@ data class QueryHandler(
     override val handlerType: MessageHandlerType = MessageHandlerType.QUERY
 
     override fun renderText(): String {
+        return "${element.containingClassname()}.${element.name}"
+    }
+
+    override fun renderContainerText(): String {
         return componentName
     }
 }

--- a/src/test/kotlin/org/axonframework/intellij/ide/plugin/markers/handlers/CommandHandlerMethodLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/axonframework/intellij/ide/plugin/markers/handlers/CommandHandlerMethodLineMarkerProviderTest.kt
@@ -140,7 +140,7 @@ class CommandHandlerMethodLineMarkerProviderTest : AbstractAxonFixtureTestCase()
 
         assertThat(hasLineMarker(CommandHandlerMethodLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(CommandHandlerMethodLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("Saga: test", null, AxonIcons.Handler)
+            OptionSummary("Saga: test", null, AxonIcons.Publisher)
         )
     }
 
@@ -175,7 +175,7 @@ class CommandHandlerMethodLineMarkerProviderTest : AbstractAxonFixtureTestCase()
 
         assertThat(hasLineMarker(CommandHandlerMethodLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(CommandHandlerMethodLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("Saga: test", null, AxonIcons.Handler)
+            OptionSummary("Saga: test", null, AxonIcons.Publisher)
         )
     }
 }

--- a/src/test/kotlin/org/axonframework/intellij/ide/plugin/markers/handlers/CommonHandlerMethodLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/axonframework/intellij/ide/plugin/markers/handlers/CommonHandlerMethodLineMarkerProviderTest.kt
@@ -52,7 +52,7 @@ class CommonHandlerMethodLineMarkerProviderTest : AbstractAxonFixtureTestCase() 
 
         assertThat(hasLineMarker(CommonHandlerMethodLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(CommonHandlerMethodLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("MyCommand", null, AxonIcons.Handler)
+            OptionSummary("MyCommand", null, AxonIcons.Publisher)
         )
     }
 
@@ -81,7 +81,7 @@ class CommonHandlerMethodLineMarkerProviderTest : AbstractAxonFixtureTestCase() 
 
         assertThat(hasLineMarker(CommonHandlerMethodLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(CommonHandlerMethodLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("MyCommand", null, AxonIcons.Handler)
+            OptionSummary("MyCommand", null, AxonIcons.Publisher)
         )
     }
 
@@ -109,7 +109,7 @@ class CommonHandlerMethodLineMarkerProviderTest : AbstractAxonFixtureTestCase() 
 
         assertThat(hasLineMarker(CommonHandlerMethodLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(CommonHandlerMethodLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("EventSourcingHandler MyAggregate", null, AxonIcons.Handler)
+            OptionSummary("EventSourcingHandler MyAggregate", null, AxonIcons.Publisher)
         )
     }
 
@@ -142,7 +142,7 @@ class CommonHandlerMethodLineMarkerProviderTest : AbstractAxonFixtureTestCase() 
 
         assertThat(hasLineMarker(CommonHandlerMethodLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(CommonHandlerMethodLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("EventSourcingHandler MyAggregate", null, AxonIcons.Handler)
+            OptionSummary("EventSourcingHandler MyAggregate", null, AxonIcons.Publisher)
         )
     }
 
@@ -170,7 +170,7 @@ class CommonHandlerMethodLineMarkerProviderTest : AbstractAxonFixtureTestCase() 
 
         assertThat(hasLineMarker(CommonHandlerMethodLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(CommonHandlerMethodLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("MyCommand", null, AxonIcons.Handler)
+            OptionSummary("MyCommand", null, AxonIcons.Publisher)
         )
     }
 
@@ -210,7 +210,7 @@ class CommonHandlerMethodLineMarkerProviderTest : AbstractAxonFixtureTestCase() 
 
         assertThat(hasLineMarker(CommonHandlerMethodLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(CommonHandlerMethodLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("MyCommand", null, AxonIcons.Handler)
+            OptionSummary("MyCommand", null, AxonIcons.Publisher)
         )
     }
 
@@ -239,7 +239,7 @@ class CommonHandlerMethodLineMarkerProviderTest : AbstractAxonFixtureTestCase() 
 
         assertThat(hasLineMarker(CommonHandlerMethodLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(CommonHandlerMethodLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("MyCommand", null, AxonIcons.Handler)
+            OptionSummary("MyCommand", null, AxonIcons.Publisher)
         )
     }
 }

--- a/src/test/kotlin/org/axonframework/intellij/ide/plugin/markers/handlers/DeadlineHandlerMethodLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/axonframework/intellij/ide/plugin/markers/handlers/DeadlineHandlerMethodLineMarkerProviderTest.kt
@@ -43,7 +43,7 @@ class DeadlineHandlerMethodLineMarkerProviderTest : AbstractAxonFixtureTestCase(
         )
         assertThat(hasLineMarker(DeadlineHandlerMethodLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(DeadlineHandlerMethodLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("MyCommand", null, AxonIcons.Handler)
+            OptionSummary("MyCommand", null, AxonIcons.Publisher)
         )
     }
 }

--- a/src/test/kotlin/org/axonframework/intellij/ide/plugin/markers/publishers/PublishMethodLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/axonframework/intellij/ide/plugin/markers/publishers/PublishMethodLineMarkerProviderTest.kt
@@ -152,7 +152,7 @@ class PublishMethodLineMarkerProviderTest : AbstractAxonFixtureTestCase() {
 
         assertThat(hasLineMarker(PublishMethodLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(PublishMethodLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("some-group", null, AxonIcons.Handler)
+            OptionSummary("MyProcessingGroup.handle", "some-group", AxonIcons.Handler)
         )
     }
 
@@ -175,7 +175,7 @@ class PublishMethodLineMarkerProviderTest : AbstractAxonFixtureTestCase() {
 
         assertThat(hasLineMarker(PublishMethodLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(PublishMethodLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("test", null, AxonIcons.Handler)
+            OptionSummary("MyProcessingGroup.handle", "test", AxonIcons.Handler)
         )
     }
 


### PR DESCRIPTION
The icon of the parent handler should not be shown, just a Publisher icon. This is still from an old version and is wrong. See issue#18. 

Also added a more descriptive entry for query handlers in the pop up