### PR TITLE
Solved memory leak by excessive caching of handler calculation result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## [0.6.0]
 
+### Fixed
+- Solved memory leak by excessive caching of handler calculation result
+
 ### Added
 
 - Users can now report their exceptions and will be stored in our Sentry installation

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/markers/handlers/AbstractHandlerLineMarkerProvider.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/markers/handlers/AbstractHandlerLineMarkerProvider.kt
@@ -21,7 +21,6 @@ import com.intellij.codeInsight.daemon.LineMarkerProvider
 import com.intellij.psi.PsiElement
 import org.axonframework.intellij.ide.plugin.api.MessageHandlerType
 import org.axonframework.intellij.ide.plugin.util.annotationResolver
-import org.axonframework.intellij.ide.plugin.util.cacheData
 import org.axonframework.intellij.ide.plugin.util.resolvePayloadType
 import org.axonframework.intellij.ide.plugin.util.toQualifiedName
 import org.jetbrains.uast.UAnnotation
@@ -38,9 +37,7 @@ import org.jetbrains.uast.toUElementOfType
  */
 abstract class AbstractHandlerLineMarkerProvider : LineMarkerProvider {
     override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? {
-        val info = element.cacheData("Axon_annotationInfo") {
-                getInfoForAnnotatedFunction(element)
-        }
+        val info = getInfoForAnnotatedFunction(element)
         if (info != null) {
             return createLineMarker(element, info.first, info.second)
         }

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/util/CacheUtils.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/util/CacheUtils.kt
@@ -17,29 +17,9 @@
 package org.axonframework.intellij.ide.plugin.util
 
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.Key
-import com.intellij.psi.PsiElement
-import com.intellij.psi.util.CachedValue
 import com.intellij.psi.util.CachedValueProvider
 import com.intellij.psi.util.CachedValuesManager
 import com.intellij.psi.util.PsiModificationTracker
-
-
-/**
- * Used to cache data on a PsiElement using the user data map.
- *
- * Uses PsiModificationTracker under the hood, so everything is re-computed when code changes.
- */
-fun <T> PsiElement.cacheData(key: String, supplier: () -> T): T {
-    val cacheKey = Key<CachedValue<T>>(key)
-    val cache = getUserData(cacheKey)
-    if (cache == null) {
-        val createCachedValue = project.createCachedValue(supplier)
-        putUserData(cacheKey, createCachedValue)
-        return createCachedValue.value
-    }
-    return cache.value
-}
 
 /**
  * Convenience method to quickly create a cached value for a project based on PSI modifications.


### PR DESCRIPTION
Eventually IntelliJ installations using the Axon Framework plugin will freeze due to the plugin not releasing memory to the GC. This seems to be caused by caching on PsiElements, causing a circular reference that the GC cannot clean up. 

This cache has been removed and should resolve the memory issues. 