### PR TITLE
[#59] Fix ClassCastException when type argument is wildcard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # Axon Framework plugin Changelog
 
+## [0.6.2]
+
+### Fixed
+- [#59] Fixed ClassCastException during querying provider ClassLineMarkerProvider (thanks @kaleev for reporting the error)
+
 ## [0.6.1]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 - [#59] Fixed ClassCastException during querying provider ClassLineMarkerProvider (thanks @kaleev for reporting the error)
+- Fix various occasions where invalid PsiElements could be shown in line marker popups by filtering on validity
 
 ## [0.6.1]
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 
 pluginGroup=io.axoniq.ide.intellij
 pluginName=Axon Framework
-pluginVersion=0.6.1
+pluginVersion=0.6.2
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/markers/AxonNavigationGutterIconRenderer.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/markers/AxonNavigationGutterIconRenderer.kt
@@ -62,7 +62,7 @@ class AxonNavigationGutterIconRenderer(
 
     override fun navigateToItems(event: MouseEvent?) {
         if (event != null) {
-            val elements = PsiUtilCore.toPsiElementArray(targetElements)
+            val elements = PsiUtilCore.toPsiElementArray(targetElements.filter { it.isValid })
             val popup = NavigationUtil.getPsiElementPopup(elements, myCellRenderer.compute(), myPopupTitle)
             popup.show(RelativePoint(event))
         }
@@ -76,7 +76,11 @@ class AxonNavigationGutterIconRenderer(
             { tooltipText },
             this,
             alignment,
-            { elements.value.map { WrappedGoToRelatedItem(it) } }
+            {
+                elements.value
+                    .filter { it.element.isValid }
+                    .map { WrappedGoToRelatedItem(it) }
+            }
         )
     }
 }

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/util/PSiProcessingUtils.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/util/PSiProcessingUtils.kt
@@ -47,15 +47,18 @@ import org.jetbrains.uast.toUElement
 
 /**
  * Convenience method to fully qualified name of type.
- * Throws if we get a type we do not expect so we can support it.
  */
 fun PsiType?.toQualifiedName(): String? = this?.let {
-    return when (this) {
-        is PsiClassReferenceType -> this.resolve()?.qualifiedName
-        // Class<SomeClass> object. Extract the <SomeClass> and call this method recursively to resolve it
-        is PsiImmediateClassType -> (this.parameters.firstOrNull() as PsiClassType?)?.toQualifiedName()
-        is PsiWildcardType -> "java.lang.Object"
-        else -> null
+    return try {
+        when (this) {
+            is PsiClassReferenceType -> this.resolve()?.qualifiedName
+            // Class<SomeClass> object. Extract the <SomeClass> and call this method recursively to resolve it
+            is PsiImmediateClassType -> this.parameters.firstOrNull()?.toQualifiedName()
+            is PsiWildcardType -> "java.lang.Object"
+            else -> null
+        }
+    } catch (e: Exception) {
+        throw IllegalArgumentException("Was unable to resolve qualifiedName type ${it.canonicalText} due to exception: ${e.message}", e)
     }
 }
 

--- a/src/test/kotlin/org/axonframework/intellij/ide/plugin/specifics/ExceptionCasesTests.kt
+++ b/src/test/kotlin/org/axonframework/intellij/ide/plugin/specifics/ExceptionCasesTests.kt
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2022. Axon Framework
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.axonframework.intellij.ide.plugin.specifics
+
+import org.axonframework.intellij.ide.plugin.AbstractAxonFixtureTestCase
+import org.axonframework.intellij.ide.plugin.util.aggregateResolver
+
+class ExceptionCasesTests : AbstractAxonFixtureTestCase() {
+    /**
+     * Tests whether the containing code does not cause a ClassCastException in the AggregateResolver
+     */
+    fun `test handles wildcard type in immediate class type`() {
+        addFile(
+            "MyAggregate.java", """
+            import java.util.List;
+            
+            @AggregateRoot
+            class MyAggregate {
+                @AggregateMember
+                private List<?> entities;
+            }
+        """.trimIndent()
+        )
+
+        project.aggregateResolver().getModels()
+    }
+}


### PR DESCRIPTION
In addition, in Sentry I have seen a small issue with validity of elements in the line marker popups. Solved this by checking on validity in `AxonNavigationGutterIconRenderer` when building the popup