### PR TITLE
[#41] Mark methods annotated with @ResetHandler as used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ### Added
 
-- Aggregate structure hierarchy is now shown in model popup
+- [#38] Aggregate structure hierarchy is now shown in model popup
+- [#41] Mark methods annotated with @ResetHandler as used
 
 ## [0.6.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [#38] Aggregate structure hierarchy is now shown in model popup
 - [#41] Mark methods annotated with @ResetHandler as used
+- Fix OutOfBoundException in AxonImplicitUsageProvider when using Groovy
 
 ## [0.6.2]
 

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/api/AxonAnnotation.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/api/AxonAnnotation.kt
@@ -27,6 +27,7 @@ enum class AxonAnnotation(val annotationName: String) {
     COMMAND_HANDLER_INTERCEPTOR("org.axonframework.modelling.command.CommandHandlerInterceptor"),
     SAGA_EVENT_HANDLER("org.axonframework.modelling.saga.SagaEventHandler"),
     DEADLINE_HANDLER("org.axonframework.deadline.annotation.DeadlineHandler"),
+    RESET_HANDLER("org.axonframework.eventhandling.ResetHandler"),
 
     AGGREGATE_ROOT("org.axonframework.modelling.command.AggregateRoot"),
     AGGREGATE_MEMBER("org.axonframework.modelling.command.AggregateMember"),

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/usage/AxonImplicitUsageProvider.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/usage/AxonImplicitUsageProvider.kt
@@ -19,7 +19,6 @@ package org.axonframework.intellij.ide.plugin.usage
 import com.intellij.codeInsight.daemon.ImplicitUsageProvider
 import com.intellij.psi.PsiElement
 import org.axonframework.intellij.ide.plugin.api.AxonAnnotation
-import org.axonframework.intellij.ide.plugin.api.MessageHandlerType
 import org.axonframework.intellij.ide.plugin.util.isAggregate
 import org.axonframework.intellij.ide.plugin.util.isAnnotated
 import org.jetbrains.uast.UClass
@@ -75,8 +74,8 @@ class AxonImplicitUsageProvider : ImplicitUsageProvider {
     }
 
 
-    private fun UMethod.isAnnotatedWithAxon() = MessageHandlerType.values().any {
-        isAnnotated(it.annotation)
+    private fun UMethod.isAnnotatedWithAxon() = AxonAnnotation.values().any {
+        isAnnotated(it)
     }
 
     private fun UField.hasRelevantAnnotation() = fieldAnnotations.any {

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/usage/AxonImplicitUsageProvider.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/usage/AxonImplicitUsageProvider.kt
@@ -48,7 +48,9 @@ class AxonImplicitUsageProvider : ImplicitUsageProvider {
         }
         if (uastElement is UParameter && uastElement.uastParent is UMethod) {
             val uMethod = uastElement.uastParent as UMethod
-            return uMethod.uastParameters[0] == uastElement && uMethod.isAnnotatedWithAxon()
+            // Apparently, when using Groovy UAST the method can have 0 parameters at this point (Sentry issue AXONIQ-18)
+            val parameter = uMethod.uastParameters.getOrNull(0)
+            return parameter != null && parameter == uastElement && uMethod.isAnnotatedWithAxon()
         }
         if (uastElement is UField) {
             return uastElement.hasRelevantAnnotation()


### PR DESCRIPTION
Als implemented a small fix with AXONIQ-18 in Sentry. Using Groovy can throw an IndexOutOfBoundsException when accessing method parameters. 

The element is an UastParameter. The parent of the UastParameter is a UastMethod. But the amount of parameters of the UastMethod are 0. It does not make sense, but we can write a guard for it. 