### PR TITLE
Various fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 - [#66] Fix possible race condition between primary and secondary cache computations in annotation resolver
+- [#68] Remove unnecessary catching of errors during resolving a qualifiedName in PsiProcessingUtil
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 - [#66] Fix possible race condition between primary and secondary cache computations in annotation resolver
 - [#68] Remove unnecessary catching of errors during resolving a qualifiedName in PsiProcessingUtil
+- [#69] Disable plugin functionality when old versions are used
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@
 
 ## [0.7.0]
 
+### Fixed
+- [#66] Fix possible race condition between primary and secondary cache computations in annotation resolver
+
 ### Added
 
-- Aggregate structure hierarchy is now shown in model popup
+- [#31] Aggregate structure hierarchy is now shown in model popup
 
 ## [0.6.2]
 

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/AnnotationResolver.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/AnnotationResolver.kt
@@ -158,7 +158,7 @@ class AnnotationResolver(val project: Project) {
          * Get all annotations in the library cache. If the cache is out-of-date, executes a scan.
          */
         fun getLibraryAnnotations(): List<ResolvedAnnotation> {
-            if (!libraryInitialized) {
+            if (!libraryInitialized || libraryAnnotations.any { !it.psiClass.isValid }) {
                 updateLibraryAnnotations()
             }
             return libraryAnnotations

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/AnnotationResolver.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/AnnotationResolver.kt
@@ -27,6 +27,7 @@ import org.axonframework.intellij.ide.plugin.api.MessageHandlerType
 import org.axonframework.intellij.ide.plugin.util.allScope
 import org.axonframework.intellij.ide.plugin.util.axonScope
 import org.axonframework.intellij.ide.plugin.util.createCachedValue
+import org.axonframework.intellij.ide.plugin.util.isAxon4Project
 import org.axonframework.intellij.ide.plugin.util.javaFacade
 
 /**
@@ -158,6 +159,10 @@ class AnnotationResolver(val project: Project) {
          * Get all annotations in the library cache. If the cache is out-of-date, executes a scan.
          */
         fun getLibraryAnnotations(): List<ResolvedAnnotation> {
+            if(!project.isAxon4Project()) {
+                return emptyList()
+            }
+
             if (!libraryInitialized || libraryAnnotations.any { !it.psiClass.isValid }) {
                 updateLibraryAnnotations()
             }

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/support/ReportingService.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/support/ReportingService.kt
@@ -19,11 +19,11 @@ package org.axonframework.intellij.ide.plugin.support
 import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.roots.OrderEnumerator
 import io.sentry.Sentry
 import io.sentry.SentryEvent
 import io.sentry.UserFeedback
 import io.sentry.protocol.Message
+import org.axonframework.intellij.ide.plugin.util.getAxonVersions
 
 /**
  * Responsible for reporting feedback and exceptions to Sentry.
@@ -66,18 +66,8 @@ class ReportingService {
     }
 
     private fun Project.addLibraryVersionsToExtras() {
-        OrderEnumerator.orderEntries(this)
-            .librariesOnly()
-            .productionOnly()
-            .satisfying { it.presentableName.matches(Regex(".*(org\\.axonframework)+.*")) }
-            .classes()
-            .roots
-            .forEach {
-                val name = it.name.replace(".jar", "")
-                val version = name.split("-").last()
-                val actualName = name.replace("-${version}", "")
-                Sentry.setExtra(actualName, version)
-            }
-
+        getAxonVersions().forEach { (actualName, version) ->
+            Sentry.setExtra(actualName, version)
+        }
     }
 }

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/util/PSiProcessingUtils.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/util/PSiProcessingUtils.kt
@@ -48,18 +48,12 @@ import org.jetbrains.uast.toUElement
 /**
  * Convenience method to fully qualified name of type.
  */
-fun PsiType?.toQualifiedName(): String? = this?.let {
-    return try {
-        when (this) {
-            is PsiClassReferenceType -> this.resolve()?.qualifiedName
-            // Class<SomeClass> object. Extract the <SomeClass> and call this method recursively to resolve it
-            is PsiImmediateClassType -> this.parameters.firstOrNull()?.toQualifiedName()
-            is PsiWildcardType -> "java.lang.Object"
-            else -> null
-        }
-    } catch (e: Exception) {
-        throw IllegalArgumentException("Was unable to resolve qualifiedName type ${it.canonicalText} due to exception: ${e.message}", e)
-    }
+fun PsiType?.toQualifiedName(): String? = when (this) {
+    is PsiClassReferenceType -> this.resolve()?.qualifiedName
+    // Class<SomeClass> object. Extract the <SomeClass> and call this method recursively to resolve it
+    is PsiImmediateClassType -> this.parameters.firstOrNull()?.toQualifiedName()
+    is PsiWildcardType -> "java.lang.Object"
+    else -> null
 }
 
 /**

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/util/ProjectUtils.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/util/ProjectUtils.kt
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2022. Axon Framework
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.axonframework.intellij.ide.plugin.util
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.OrderEnumerator
+
+val versionRegex = Regex("^4\\.\\d+\\.\\d+$")
+
+fun Project.isAxon4Project() = getAxonVersions().values.any { it.matches(versionRegex) }
+
+fun Project.getAxonVersions() = OrderEnumerator.orderEntries(this)
+    .librariesOnly()
+    .productionOnly()
+    .satisfying { it.presentableName.matches(Regex(".*(org\\.axonframework)+.*")) }
+    .classes()
+    .roots.associate {
+        val name = it.name.replace(".jar", "").replace("-SNAPSHOT", "")
+        val version = name.split("-").last()
+        val actualName = name.replace("-${version}", "")
+        actualName to version
+    }

--- a/src/test/kotlin/org/axonframework/intellij/ide/plugin/specifics/ExceptionCasesTests.kt
+++ b/src/test/kotlin/org/axonframework/intellij/ide/plugin/specifics/ExceptionCasesTests.kt
@@ -36,6 +36,6 @@ class ExceptionCasesTests : AbstractAxonFixtureTestCase() {
         """.trimIndent()
         )
 
-        project.aggregateResolver().getModels()
+        project.aggregateResolver().getMemberForName("text.MyAggregate")
     }
 }


### PR DESCRIPTION
Fixes the following issues:

- [#66] Fix possible race condition between primary and secondary cache computations in annotation resolver
- [#68] Remove unnecessary catching of errors during resolving a qualifiedName in PsiProcessingUtil
- [#69] Disable plugin functionality when old versions are used
