### PR TITLE
PR for issue / feature #107

### DIFF
--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/util/ProjectUtils.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/util/ProjectUtils.kt
@@ -19,9 +19,15 @@ package org.axonframework.intellij.ide.plugin.util
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.OrderEnumerator
 
-val versionRegex = Regex("^4\\.\\d+\\.\\d+$")
+const val moduleNamePart = "^.*"
+const val versionPart = "4\\.\\d+\\.\\d"
 
-fun Project.isAxon4Project() = getAxonVersions().values.any { it.matches(versionRegex) }
+val versionRegex = Regex("^$versionPart$")
+val capturingRegex = Regex("($moduleNamePart)-($versionPart)(?:-.*)*")
+
+fun Project.isAxon4Project() = getAxonVersions().values.any {
+    return it.matches(versionRegex)
+}
 
 fun Project.getAxonVersions() = OrderEnumerator.orderEntries(this)
     .librariesOnly()
@@ -29,8 +35,7 @@ fun Project.getAxonVersions() = OrderEnumerator.orderEntries(this)
     .satisfying { it.presentableName.matches(Regex(".*(org\\.axonframework)+.*")) }
     .classes()
     .roots.associate {
-        val name = it.name.replace(".jar", "").replace("-SNAPSHOT", "")
-        val version = name.split("-").last()
-        val actualName = name.replace("-${version}", "")
-        actualName to version
+        val match = capturingRegex.find(it.name)!!
+        val (moduleName, version) = match.destructured
+        moduleName to version
     }

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/util/ProjectUtils.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/util/ProjectUtils.kt
@@ -20,7 +20,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.OrderEnumerator
 
 const val moduleNamePart = "^.*"
-const val versionPart = "4\\.\\d+\\.\\d"
+const val versionPart = "4\\.\\d+\\.\\d+"
 
 val versionRegex = Regex("^$versionPart$")
 val capturingRegex = Regex("($moduleNamePart)-($versionPart)(?:-*.*)")

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/util/ProjectUtils.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/util/ProjectUtils.kt
@@ -23,7 +23,7 @@ const val moduleNamePart = "^.*"
 const val versionPart = "4\\.\\d+\\.\\d"
 
 val versionRegex = Regex("^$versionPart$")
-val capturingRegex = Regex("($moduleNamePart)-($versionPart)(?:-.*)*")
+val capturingRegex = Regex("($moduleNamePart)-($versionPart)(?:-*.*)")
 
 fun Project.isAxon4Project() = getAxonVersions().values.any {
     return it.matches(versionRegex)


### PR DESCRIPTION
The existing code works with any module name with `-SNAPSHOT` e.g., `axon-spring-boot-autoconfigure-4.6.0-SNAPSHOT.jar` by dropping the `.jar` and `-SNAPSHOT` then splitting the remianing name and using `.last()` on the split to obtain the version of `4.6.0`.

This functionality fails when using maven with snapshot dependencies that have been updated to something more like `axon-spring-boot-autoconfigure-4.6.0-20220622.093707-365`, in this case the version is returned as '465' and the module name is also reported incorrectly.

This PR replaces the existing behaviour with a regex containing two capturing groups, the first captures the module name, the second the module version. It has been tested with the following values:-

- `axon-spring-boot-autoconfigure-4.5.10.jar`
- `axon-spring-boot-autoconfigure-4.6.0-SNAPSHOT.jar`
- `axon-spring-boot-autoconfigure-4.6.0-20220622.093707-365.jar`

