### PR TITLE
Fix tests and add to GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,10 @@ jobs:
 
             -   name: Validate Gradle wrapper
                 uses: gradle/wrapper-validation-action@v1
-
+            -   name: Test plugin
+                uses: gradle/gradle-build-action@v2.2.1
+                with:
+                    arguments: test
             -   name: Verify plugin
                 uses: gradle/gradle-build-action@v2.2.1
                 with:

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/util/ProjectUtils.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/util/ProjectUtils.kt
@@ -32,7 +32,7 @@ fun Project.isAxon4Project() = getAxonVersions().values.any {
 fun Project.getAxonVersions() = OrderEnumerator.orderEntries(this)
     .librariesOnly()
     .productionOnly()
-    .satisfying { it.presentableName.matches(Regex(".*(org\\.axonframework)+.*")) }
+    .satisfying { it.presentableName.matches(Regex(".*(axon-).*")) }
     .classes()
     .roots.associate {
         extractVersion(it.name)

--- a/src/test/kotlin/org/axonframework/intellij/ide/plugin/specifics/ExceptionCasesTests.kt
+++ b/src/test/kotlin/org/axonframework/intellij/ide/plugin/specifics/ExceptionCasesTests.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022. Axon Framework
+ *  Copyright (c) (2010-2022). Axon Framework
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -36,6 +36,6 @@ class ExceptionCasesTests : AbstractAxonFixtureTestCase() {
         """.trimIndent()
         )
 
-        project.aggregateResolver().getMemberForName("text.MyAggregate")
+        project.aggregateResolver().getEntityMembersByName("text.MyAggregate")
     }
 }


### PR DESCRIPTION
Appararently the tests were not run in Github. Since the introduction of the Axon 4 check, tests were broken since the module root naming is different while testing than while actually running IntelliJ. Adjusted the Regex to account for this. 