### PR TITLE
Add method consideration to Aggregate ID inspection

### DIFF
--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/api/Entity.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/api/Entity.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022. Axon Framework
+ *  Copyright (c) (2010-2022). Axon Framework
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ data class Entity(
     val clazz: PsiClass,
     val parent: String?,
     val routingKey: String?,
+    val routingKeyType: String?,
     val members: List<EntityMember>
 )
 

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/inspections/aggregate/KotlinAggregateIdInspection.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/inspections/aggregate/KotlinAggregateIdInspection.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022. Axon Framework
+ *  Copyright (c) (2010-2022). Axon Framework
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -45,12 +45,22 @@ class KotlinAggregateIdInspection : AbstractKotlinInspection() {
                 if (!uClass.hasAnnotation(AxonAnnotation.AGGREGATE_ROOT)) {
                     return
                 }
-                val isMissingFieldWithAnnotation =
-                    uClass.fields.none { field -> field.isAnnotated(AxonAnnotation.ENTITY_ID) }
+                val hasField = uClass.fields.none { field -> field.isAnnotated(AxonAnnotation.ENTITY_ID) }
+                val method = uClass.methods.firstOrNull { method -> method.isAnnotated(AxonAnnotation.ENTITY_ID) }
+                val isMissingFieldWithAnnotation = !hasField && method == null
                 if (isMissingFieldWithAnnotation) {
                     holder.registerProblem(
                         element,
                         aggregateIdDescription,
+                        ProblemHighlightType.WARNING,
+                        element.identifyingElement!!.textRangeInParent,
+                    )
+                }
+
+                if(method != null && method.returnType?.presentableText == "void") {
+                    holder.registerProblem(
+                        element,
+                        aggregateIdVoidDescription,
                         ProblemHighlightType.WARNING,
                         element.identifyingElement!!.textRangeInParent,
                     )

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/inspections/aggregate/descriptions.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/inspections/aggregate/descriptions.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022. Axon Framework
+ *  Copyright (c) (2010-2022). Axon Framework
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -18,11 +18,16 @@ package org.axonframework.intellij.ide.plugin.inspections.aggregate
 
 
 const val aggregateIdStaticDescription =
-    """Inspects Java aggregate classes to check whether they have a field that the framework can use to identify it."""
+    """Inspects Java aggregate classes to check whether they have a member that the framework can use to identify it."""
 
 const val aggregateIdDescription =
-    """<html>Axon Framework requires a field annotated with @AggregateIdentifier to be able identify the aggregate.
-Please add such a field to the aggregate. Also see <a href="https://docs.axoniq.io/reference-guide/axon-framework/axon-framework-commands/modeling/aggregate"> the reference guide</a> for more information.
+    """<html>Axon Framework requires a member annotated with @AggregateIdentifier to be able identify the aggregate.
+Please add such a member to the aggregate. Also see <a href="https://docs.axoniq.io/reference-guide/axon-framework/axon-framework-commands/modeling/aggregate"> the reference guide</a> for more information.
+</html>"""
+
+const val aggregateIdVoidDescription =
+    """<html>You have annotated a method with @AggregateIdentifier, but this is a void method.
+Please return a valid value from this member. Also see <a href="https://docs.axoniq.io/reference-guide/axon-framework/axon-framework-commands/modeling/aggregate"> the reference guide</a> for more information.
 </html>"""
 
 const val emptyConstructorStaticDescription =

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/util/PSiProcessingUtils.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/util/PSiProcessingUtils.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022. Axon Framework
+ *  Copyright (c) (2010-2022). Axon Framework
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import com.intellij.psi.PsiClassType
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiJvmModifiersOwner
 import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiPrimitiveType
 import com.intellij.psi.PsiType
 import com.intellij.psi.PsiWildcardType
 import com.intellij.psi.impl.source.PsiClassReferenceType
@@ -54,6 +55,7 @@ fun PsiType?.toQualifiedName(): String? = when (this) {
     // Class<SomeClass> object. Extract the <SomeClass> and call this method recursively to resolve it
     is PsiImmediateClassType -> this.parameters.firstOrNull()?.toQualifiedName()
     is PsiWildcardType -> "java.lang.Object"
+    is PsiPrimitiveType -> if(name == "void") "void" else null
     else -> null
 }
 

--- a/src/test/kotlin/org/axonframework/intellij/ide/plugin/inspections/aggregate/JavaAggregateIdInspectionTest.kt
+++ b/src/test/kotlin/org/axonframework/intellij/ide/plugin/inspections/aggregate/JavaAggregateIdInspectionTest.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022. Axon Framework
+ *  Copyright (c) (2010-2022). Axon Framework
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -70,6 +70,54 @@ class JavaAggregateIdInspectionTest : AbstractAxonFixtureTestCase() {
         val highlights = myFixture.doHighlighting(HighlightSeverity.WARNING)
         assertThat(highlights).noneMatch { it.text == "MyAggregate" }
     }
+
+    fun `test should not detect when aggregate has an identifier defined by getter`() {
+        val file = addFile(
+            "MyAggregate.java", """            
+            @AggregateRoot
+            public class MyAggregate {
+                private String part1;
+                private String part2;
+    
+                @AggregateIdentifier
+                public String aggregateIdentifier() {
+                    return part1 + ":" + part2;
+                }
+                
+            }
+        """.trimIndent()
+        )
+
+        myFixture.enableInspections(JavaAggregateIdInspection())
+        myFixture.openFileInEditor(file)
+        val highlights = myFixture.doHighlighting(HighlightSeverity.WARNING)
+        assertThat(highlights).noneMatch { it.text == "MyAggregate" }
+    }
+
+    fun `test should detect when aggregate has an identifier defined by getter but has void return type`() {
+        val file = addFile(
+            "MyAggregate.java", """            
+            @AggregateRoot
+            public class MyAggregate {
+                private String part1;
+                private String part2;
+    
+                @AggregateIdentifier
+                public void aggregateIdentifier() {
+                }
+                
+            }
+        """.trimIndent()
+        )
+
+        myFixture.enableInspections(JavaAggregateIdInspection())
+        myFixture.openFileInEditor(file)
+        val highlights = myFixture.doHighlighting(HighlightSeverity.WARNING)
+        assertThat(highlights).anyMatch {
+            it.text == "MyAggregate" && it.description.contains("You have annotated a method with @AggregateIdentifier, but this is a void method.")
+        }
+    }
+
 
     fun `test should also allow EntityId annotation`() {
         val file = addFile(

--- a/src/test/kotlin/org/axonframework/intellij/ide/plugin/inspections/aggregate/KotlinAggregateIdInspectionTest.kt
+++ b/src/test/kotlin/org/axonframework/intellij/ide/plugin/inspections/aggregate/KotlinAggregateIdInspectionTest.kt
@@ -34,7 +34,7 @@ class KotlinAggregateIdInspectionTest : AbstractAxonFixtureTestCase() {
         myFixture.openFileInEditor(file)
         val highlights = myFixture.doHighlighting(HighlightSeverity.WARNING)
         Assertions.assertThat(highlights).anyMatch {
-            it.text == "MyAggregate" && it.description.contains("requires a field annotated with @AggregateIdentifier")
+            it.text == "MyAggregate" && it.description.contains("requires a member annotated with @AggregateIdentifier")
         }
     }
 
@@ -79,6 +79,29 @@ class KotlinAggregateIdInspectionTest : AbstractAxonFixtureTestCase() {
             public class MyAggregate {
                 @AggregateIdentifier
                 fun getIdentifier(): String = "MyIdentifier"
+            }
+        """.trimIndent()
+        )
+
+        myFixture.enableInspections(KotlinAggregateIdInspection())
+        myFixture.openFileInEditor(file)
+        val highlights = myFixture.doHighlighting(HighlightSeverity.WARNING)
+        Assertions.assertThat(highlights).noneMatch { it.text == "MyAggregate" }
+    }
+
+    fun `test should not detect when aggregate has an identifier defined in superclass`() {
+        val file = addFile(
+            "MyAggregate.kt", """    
+                        
+                        
+            @AggregateRoot
+            public class MySuperAggregate {
+                @AggregateIdentifier
+                fun getIdentifier(): String = "MyIdentifier"
+            }     
+            
+            @AggregateRoot
+            public class MyAggregate : MySuperAggregate() {
             }
         """.trimIndent()
         )


### PR DESCRIPTION
Fixes a bug where placing an `@AggregateIdentifier` annotation on a method would not be considered valid. It now is considered valid. 
Also added a specific rule that the return type of this method may not be null. 
In addition we now scan the superclasses of the aggregate for this routing key as well, and the inspection in powered by this information. 

Closes #89 
Closes #80