### PR TITLE
Remove the link between creators and parent handlers

### DIFF
--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/api/AxonAnnotation.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/api/AxonAnnotation.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022. Axon Framework
+ *  Copyright (c) (2010-2022). Axon Framework
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ enum class AxonAnnotation(val annotationName: String) {
     AGGREGATE_MEMBER("org.axonframework.modelling.command.AggregateMember"),
     ROUTING_KEY("org.axonframework.commandhandling.RoutingKey"),
     ENTITY_ID("org.axonframework.modelling.command.EntityId"),
-    PROCESSING_GROUP("org.axonframework.config.ProcessingGroup")
+    PROCESSING_GROUP("org.axonframework.config.ProcessingGroup"),
+    SAGA("org.axonframework.config.ProcessingGroup")
     ;
 }

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/api/MessageCreator.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/api/MessageCreator.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022. Axon Framework
+ *  Copyright (c) (2010-2022). Axon Framework
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -27,12 +27,5 @@ interface MessageCreator : PsiElementWrapper {
      * it's the payload type.
      */
     val payload: String
-
-    /**
-     * The parent handler that published the message. For example, if this MessageCreator represents an event
-     * created by a CommandHandler, the parentHandler will be that CommandHandler.
-     * The same applied for commands created by a SagaEventHandler, among others.
-     */
-    val parentHandler: Handler?
 }
 

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/api/PsiElementWrapper.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/api/PsiElementWrapper.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022. Axon Framework
+ *  Copyright (c) (2010-2022). Axon Framework
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package org.axonframework.intellij.ide.plugin.api
 
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiElement
-import org.axonframework.intellij.ide.plugin.util.containingClassname
+import org.axonframework.intellij.ide.plugin.util.toViewText
 import org.jetbrains.uast.UMethod
 import org.jetbrains.uast.getParentOfType
 import org.jetbrains.uast.toUElement
@@ -40,7 +40,7 @@ interface PsiElementWrapper {
     fun renderText(): String {
         val methodParent = element.toUElement()?.getParentOfType<UMethod>()
         if (methodParent != null) {
-            return methodParent.containingClassname() + "." + methodParent.name
+            return methodParent.toViewText()
         }
 
         if (element is PsiClass) {

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/markers/ClassLineMarkerProvider.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/markers/ClassLineMarkerProvider.kt
@@ -49,7 +49,7 @@ class ClassLineMarkerProvider : LineMarkerProvider {
             if (handlers.isNotEmpty()) {
                 return AxonNavigationGutterIconRenderer(
                     icon = AxonIcons.Axon,
-                    popupTitle = "Axon References To This Class",
+                    popupTitle = "Axon References To $qualifiedName",
                     tooltipText = "Navigate to message handlers and creations",
                     emptyText = "No references were found",
                     elements = NotNullLazyValue.createValue {

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/markers/handlers/CommandHandlerMethodLineMarkerProvider.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/markers/handlers/CommandHandlerMethodLineMarkerProvider.kt
@@ -50,7 +50,6 @@ class CommandHandlerMethodLineMarkerProvider : AbstractHandlerLineMarkerProvider
             emptyText = "No creators of this message payload were found",
             elements = ValidatingLazyValue(element) {
                 val creatingElements = element.creatorResolver().getCreatorsForPayload(payload)
-                    .distinctBy { it.parentHandler }
                 interceptingElements + creatingElements
             })
             .createLineMarkerInfo(element)

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/markers/handlers/CommonHandlerMethodLineMarkerProvider.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/markers/handlers/CommonHandlerMethodLineMarkerProvider.kt
@@ -44,7 +44,6 @@ class CommonHandlerMethodLineMarkerProvider : AbstractHandlerLineMarkerProvider(
             emptyText = "No creators of this message payload were found",
             elements = ValidatingLazyValue(element) {
                 element.creatorResolver().getCreatorsForPayload(payload)
-                    .distinctBy { it.parentHandler }
             }).createLineMarkerInfo(element)
     }
 }

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/markers/handlers/DeadlineHandlerMethodLineMarkerProvider.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/markers/handlers/DeadlineHandlerMethodLineMarkerProvider.kt
@@ -54,7 +54,6 @@ class DeadlineHandlerMethodLineMarkerProvider : AbstractHandlerLineMarkerProvide
             emptyText = "No deadline schedule invocations could be found",
             elements = ValidatingLazyValue(element) {
                 element.deadlineReferenceResolver().findByDeadlineName(deadlineName)
-                    .distinctBy { it.parentHandler }
             }).createLineMarkerInfo(element)
     }
 }

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/DeadlineManagerReferenceResolver.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/DeadlineManagerReferenceResolver.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022. Axon Framework
+ *  Copyright (c) (2010-2022). Axon Framework
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import org.axonframework.intellij.ide.plugin.resolving.creators.DefaultMessageCr
 import org.axonframework.intellij.ide.plugin.util.axonScope
 import org.axonframework.intellij.ide.plugin.util.createCachedValue
 import org.axonframework.intellij.ide.plugin.util.deadlineMethodResolver
-import org.axonframework.intellij.ide.plugin.util.findParentHandlers
 import org.axonframework.intellij.ide.plugin.util.toQualifiedName
 import org.jetbrains.uast.UCallExpression
 import org.jetbrains.uast.evaluateString
@@ -117,10 +116,6 @@ class DeadlineManagerReferenceResolver(val project: Project) {
     }
 
     private fun createCreators(payload: String, element: PsiElement): List<MessageCreator> {
-        val parentHandlers = element.findParentHandlers()
-        if (parentHandlers.isEmpty()) {
-            return listOf(DefaultMessageCreator(element, payload, null))
-        }
-        return parentHandlers.map { DefaultMessageCreator(element, payload, it) }
+        return listOf(DefaultMessageCreator(element, payload, true))
     }
 }

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/MessageCreationResolver.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/MessageCreationResolver.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022. Axon Framework
+ *  Copyright (c) (2010-2022). Axon Framework
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package org.axonframework.intellij.ide.plugin.resolving
 
 import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiElement
 import com.intellij.psi.search.searches.MethodReferencesSearch
 import com.intellij.psi.util.CachedValue
 import org.axonframework.intellij.ide.plugin.api.MessageCreator
@@ -25,7 +24,6 @@ import org.axonframework.intellij.ide.plugin.resolving.creators.DefaultMessageCr
 import org.axonframework.intellij.ide.plugin.util.areAssignable
 import org.axonframework.intellij.ide.plugin.util.axonScope
 import org.axonframework.intellij.ide.plugin.util.createCachedValue
-import org.axonframework.intellij.ide.plugin.util.findParentHandlers
 import org.axonframework.intellij.ide.plugin.util.handlerResolver
 import org.axonframework.intellij.ide.plugin.util.javaFacade
 import java.util.concurrent.ConcurrentHashMap
@@ -74,17 +72,9 @@ class MessageCreationResolver(private val project: Project) {
                 val methods = clazz.constructors + clazz.methods.filter { it.name.contains("build", ignoreCase = true) }
                 methods
                     .flatMap { MethodReferencesSearch.search(it, project.axonScope(), true) }
-                    .flatMap { ref -> createCreators(typeFqn, ref.element) }
+                    .map { ref -> DefaultMessageCreator(ref.element, typeFqn, false) }
                     .distinct()
             }
         }
-    }
-
-    private fun createCreators(payload: String, element: PsiElement): List<MessageCreator> {
-        val parentHandlers = element.findParentHandlers()
-        if (parentHandlers.isEmpty()) {
-            return listOf(DefaultMessageCreator(element, payload, null))
-        }
-        return parentHandlers.map { DefaultMessageCreator(element, payload, it) }
     }
 }

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/creators/DefaultMessageCreator.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/creators/DefaultMessageCreator.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022. Axon Framework
+ *  Copyright (c) (2010-2022). Axon Framework
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@ package org.axonframework.intellij.ide.plugin.resolving.creators
 
 import com.intellij.psi.PsiElement
 import org.axonframework.intellij.ide.plugin.AxonIcons
-import org.axonframework.intellij.ide.plugin.api.Handler
 import org.axonframework.intellij.ide.plugin.api.MessageCreator
+import org.jetbrains.kotlin.idea.core.util.getLineNumber
 import javax.swing.Icon
 
 /**
@@ -34,7 +34,7 @@ import javax.swing.Icon
 data class DefaultMessageCreator(
     override val element: PsiElement,
     override val payload: String,
-    override val parentHandler: Handler?,
+    val isDeadline: Boolean = false,
 ) : MessageCreator {
 
     /**
@@ -45,9 +45,13 @@ data class DefaultMessageCreator(
     }
 
     override fun renderText(): String {
-        if (parentHandler != null) {
-            return parentHandler.renderText()
+        return super.renderText() + ":" + element.getLineNumber()
+    }
+
+    override fun renderContainerText(): String? {
+        if (isDeadline) {
+            return payload
         }
-        return super.renderText()
+        return null
     }
 }

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/searchers/EventHandlerSearcher.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/searchers/EventHandlerSearcher.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022. Axon Framework
+ *  Copyright (c) (2010-2022). Axon Framework
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import org.axonframework.intellij.ide.plugin.util.toQualifiedName
 /**
  * Searches for any event handlers that are not part of the aggregate model.
  *
- * @see org.axonframework.intellij.ide.plugin.handlers.types.EventHandler
+ * @see org.axonframework.intellij.ide.plugin.resolving.handlers.types.EventHandler
  */
 class EventHandlerSearcher : AbstractHandlerSearcher(MessageHandlerType.EVENT) {
     override fun createMessageHandler(method: PsiMethod, annotation: PsiClass?): Handler? {

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/types/CommandHandler.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/types/CommandHandler.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022. Axon Framework
+ *  Copyright (c) (2010-2022). Axon Framework
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import com.intellij.psi.PsiMethod
 import org.axonframework.intellij.ide.plugin.api.Handler
 import org.axonframework.intellij.ide.plugin.api.MessageHandlerType
 import org.axonframework.intellij.ide.plugin.util.toShortName
+import org.axonframework.intellij.ide.plugin.util.toViewText
 
 /**
  * Represents a method being able to handle a command.
@@ -33,6 +34,10 @@ data class CommandHandler(
     val componentName: String,
 ) : Handler {
     override val handlerType: MessageHandlerType = MessageHandlerType.COMMAND
+
+    override fun renderText(): String {
+        return element.toViewText()
+    }
 
     override fun renderContainerText(): String {
         return componentName.toShortName()

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/types/CommandHandlerInterceptor.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/types/CommandHandlerInterceptor.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022. Axon Framework
+ *  Copyright (c) (2010-2022). Axon Framework
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import com.intellij.psi.PsiMethod
 import org.axonframework.intellij.ide.plugin.AxonIcons
 import org.axonframework.intellij.ide.plugin.api.Handler
 import org.axonframework.intellij.ide.plugin.api.MessageHandlerType
-import org.axonframework.intellij.ide.plugin.util.toShortName
+import org.axonframework.intellij.ide.plugin.util.toViewText
 import javax.swing.Icon
 
 /**
@@ -37,11 +37,11 @@ data class CommandHandlerInterceptor(
     override val handlerType: MessageHandlerType = MessageHandlerType.COMMAND_INTERCEPTOR
 
     override fun renderText(): String {
-        return "Command Interceptor of ${componentName.toShortName()}"
+        return element.toViewText()
     }
 
     override fun renderContainerText(): String {
-        return element.name
+        return "Command interceptor"
     }
 
     override fun getIcon(): Icon {

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/types/DeadlineHandler.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/types/DeadlineHandler.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022. Axon Framework
+ *  Copyright (c) (2010-2022). Axon Framework
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.axonframework.intellij.ide.plugin.resolving.handlers.types
 import com.intellij.psi.PsiMethod
 import org.axonframework.intellij.ide.plugin.api.Handler
 import org.axonframework.intellij.ide.plugin.api.MessageHandlerType
+import org.axonframework.intellij.ide.plugin.util.toViewText
 
 /**
  * Represents a method being able to a deadline message. Invoked when a deadline expires.
@@ -33,6 +34,6 @@ data class DeadlineHandler(
     override val handlerType: MessageHandlerType = MessageHandlerType.DEADLINE
 
     override fun renderText(): String {
-        return "Deadline $deadlineName"
+        return element.toViewText()
     }
 }

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/types/EventHandler.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/types/EventHandler.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022. Axon Framework
+ *  Copyright (c) (2010-2022). Axon Framework
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package org.axonframework.intellij.ide.plugin.resolving.handlers.types
 import com.intellij.psi.PsiMethod
 import org.axonframework.intellij.ide.plugin.api.Handler
 import org.axonframework.intellij.ide.plugin.api.MessageHandlerType
-import org.axonframework.intellij.ide.plugin.util.containingClassname
+import org.axonframework.intellij.ide.plugin.util.toViewText
 
 /**
  * Represents a method being able to handle an event. There are more specific event handlers (`EventSourcingHandler` and
@@ -40,7 +40,7 @@ data class EventHandler(
     override val handlerType: MessageHandlerType = MessageHandlerType.EVENT
 
     override fun renderText(): String {
-        return element.containingClassname().ifEmpty { "Event Processor" }
+        return element.toViewText()
     }
 
     override fun renderContainerText(): String {

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/types/EventSourcingHandler.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/types/EventSourcingHandler.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022. Axon Framework
+ *  Copyright (c) (2010-2022). Axon Framework
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package org.axonframework.intellij.ide.plugin.resolving.handlers.types
 import com.intellij.psi.PsiMethod
 import org.axonframework.intellij.ide.plugin.api.Handler
 import org.axonframework.intellij.ide.plugin.api.MessageHandlerType
-import org.axonframework.intellij.ide.plugin.util.toShortName
+import org.axonframework.intellij.ide.plugin.util.toViewText
 
 /**
  * Represents a method being able to handle an event for sourcing an aggregate.
@@ -35,6 +35,10 @@ data class EventSourcingHandler(
     override val handlerType: MessageHandlerType = MessageHandlerType.EVENT_SOURCING
 
     override fun renderText(): String {
-        return "EventSourcingHandler " + entity.toShortName()
+        return element.toViewText()
+    }
+
+    override fun renderContainerText(): String {
+        return "EventSourcingHandler"
     }
 }

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/types/QueryHandler.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/types/QueryHandler.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022. Axon Framework
+ *  Copyright (c) (2010-2022). Axon Framework
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package org.axonframework.intellij.ide.plugin.resolving.handlers.types
 import com.intellij.psi.PsiMethod
 import org.axonframework.intellij.ide.plugin.api.Handler
 import org.axonframework.intellij.ide.plugin.api.MessageHandlerType
-import org.axonframework.intellij.ide.plugin.util.containingClassname
+import org.axonframework.intellij.ide.plugin.util.toViewText
 
 /**
  * Represents a method being able to handle a query.
@@ -35,7 +35,7 @@ data class QueryHandler(
     override val handlerType: MessageHandlerType = MessageHandlerType.QUERY
 
     override fun renderText(): String {
-        return "${element.containingClassname()}.${element.name}"
+        return element.toViewText()
     }
 
     override fun renderContainerText(): String {

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/types/SagaEventHandler.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/types/SagaEventHandler.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022. Axon Framework
+ *  Copyright (c) (2010-2022). Axon Framework
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.axonframework.intellij.ide.plugin.resolving.handlers.types
 import com.intellij.psi.PsiMethod
 import org.axonframework.intellij.ide.plugin.api.Handler
 import org.axonframework.intellij.ide.plugin.api.MessageHandlerType
+import org.axonframework.intellij.ide.plugin.util.toViewText
 
 /**
  * Represents a method in a Saga that is able to handle an event
@@ -34,6 +35,10 @@ data class SagaEventHandler(
     override val handlerType: MessageHandlerType = MessageHandlerType.SAGA
 
     override fun renderText(): String {
-        return "Saga: $processingGroup"
+        return element.toViewText()
+    }
+
+    override fun renderContainerText(): String {
+        return processingGroup
     }
 }

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/util/PSiProcessingUtils.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/util/PSiProcessingUtils.kt
@@ -56,7 +56,7 @@ fun PsiType?.toQualifiedName(): String? = when (this) {
     // Class<SomeClass> object. Extract the <SomeClass> and call this method recursively to resolve it
     is PsiImmediateClassType -> this.parameters.firstOrNull()?.toQualifiedName()
     is PsiWildcardType -> "java.lang.Object"
-    is PsiPrimitiveType -> if(name == "void") "void" else null
+    is PsiPrimitiveType -> name
     else -> null
 }
 

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/util/PsiMethodUtils.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/util/PsiMethodUtils.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022. Axon Framework
+ *  Copyright (c) (2010-2022). Axon Framework
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -25,7 +25,23 @@ import org.axonframework.intellij.ide.plugin.api.AxonAnnotation
  */
 fun PsiMethod.findProcessingGroup(): String {
     val containingClass = this.containingClass ?: return ""
-    return containingClass.resolveAnnotationStringValue(AxonAnnotation.PROCESSING_GROUP, "value") ?: toPackageName()
+    return containingClass.resolveAnnotationStringValue(AxonAnnotation.PROCESSING_GROUP, "value")
+        ?: if (this.isAnnotated(AxonAnnotation.SAGA_EVENT_HANDLER)) {
+            containingClassFqn()
+        } else toPackageName()
+}
+
+fun PsiMethod.toViewText(): String {
+    return buildString {
+        append(containingClassname())
+        if(!isConstructor) {
+            append(".")
+            append(name)
+        }
+        append("(")
+        append(parameterList.parameters.joinToString(separator = ", ") { it.type.toQualifiedName()?.toShortName() ?: "Unknown" })
+        append(")")
+    }
 }
 
 fun PsiMethod.containingClassname() = containingClass?.name ?: ""

--- a/src/test/kotlin/org/axonframework/intellij/ide/plugin/AbstractAxonFixtureTestCase.kt
+++ b/src/test/kotlin/org/axonframework/intellij/ide/plugin/AbstractAxonFixtureTestCase.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022. Axon Framework
+ *  Copyright (c) (2010-2022). Axon Framework
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -103,6 +103,10 @@ abstract class AbstractAxonFixtureTestCase : LightJavaCodeInsightFixtureTestCase
         "java.time.Instant",
     )
 
+    protected fun actualLineNumber(lineNumber: Int): Int {
+        return lineNumber + autoImports.size + 2
+    }
+
     /**
      * Adds a file to the project with given name/path and content.
      * You can skipp importing any Axon annotations defined in autoImports, they are added automagically.
@@ -114,7 +118,7 @@ abstract class AbstractAxonFixtureTestCase : LightJavaCodeInsightFixtureTestCase
         var content = ""
         content += "package $pckg$newLineChar\n\n"
         autoImports.forEach { content += "import $it$newLineChar\n" }
-        content += ("\n" + text)
+        content += ("\n" + text.trim())
         // Save <caret> position
         val caretPosition = content.indexOf("<caret>")
         content = content.replace("<caret>", "")

--- a/src/test/kotlin/org/axonframework/intellij/ide/plugin/creators/MessageCreatorResolverTest.kt
+++ b/src/test/kotlin/org/axonframework/intellij/ide/plugin/creators/MessageCreatorResolverTest.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022. Axon Framework
+ *  Copyright (c) (2010-2022). Axon Framework
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ class MessageCreatorResolverTest : AbstractAxonFixtureTestCase() {
         )
         val creators = project.creatorResolver().getCreatorsForPayload("test.MyEvent2")
         Assertions.assertThat(creators).anyMatch {
-            it.payload == "test.MyEvent2" && it.renderText() == "EventSourcingHandler MyAggregate"
+            it.payload == "test.MyEvent2" && it.renderText().startsWith("MyAggregate.handle(MyEvent)")
         }
     }
 
@@ -102,7 +102,7 @@ class MessageCreatorResolverTest : AbstractAxonFixtureTestCase() {
         val creators = project.creatorResolver().getCreatorsForPayload("test.MyCommand")
         Assertions.assertThat(creators).anyMatch {
             it.payload == "test.MyCommand" &&
-                    it.renderText() == "Saga: fancy-saga"
+                    it.renderText().startsWith("MySaga.handle(MyEvent)")
         }
     }
 

--- a/src/test/kotlin/org/axonframework/intellij/ide/plugin/markers/ClassLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/axonframework/intellij/ide/plugin/markers/ClassLineMarkerProviderTest.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022. Axon Framework
+ *  Copyright (c) (2010-2022). Axon Framework
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ class ClassLineMarkerProviderTest : AbstractAxonFixtureTestCase() {
         )
         Assertions.assertThat(hasLineMarker(ClassLineMarkerProvider::class.java)).isTrue
         Assertions.assertThat(getLineMarkerOptions(ClassLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("MyCommand", "MyAggregate", AxonIcons.Handler)
+            OptionSummary("MyAggregate.handle(MyCommand)", "MyAggregate", AxonIcons.Handler)
         )
     }
 
@@ -64,7 +64,7 @@ class ClassLineMarkerProviderTest : AbstractAxonFixtureTestCase() {
         )
         Assertions.assertThat(hasLineMarker(ClassLineMarkerProvider::class.java)).isTrue
         Assertions.assertThat(getLineMarkerOptions(ClassLineMarkerProvider::class.java)).contains(
-            OptionSummary("MyPublisher.publish", null, AxonIcons.Publisher)
+            OptionSummary("MyPublisher.publish():${actualLineNumber(13)}", null, AxonIcons.Publisher)
         )
     }
 

--- a/src/test/kotlin/org/axonframework/intellij/ide/plugin/markers/handlers/CommandHandlerMethodLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/axonframework/intellij/ide/plugin/markers/handlers/CommandHandlerMethodLineMarkerProviderTest.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022. Axon Framework
+ *  Copyright (c) (2010-2022). Axon Framework
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -112,7 +112,7 @@ class CommandHandlerMethodLineMarkerProviderTest : AbstractAxonFixtureTestCase()
 
         assertThat(hasLineMarker(CommandHandlerMethodLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(CommandHandlerMethodLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("Command Interceptor of MyAggregate", "intercept", AxonIcons.Interceptor)
+            OptionSummary("MyAggregate.intercept()", "Command interceptor", AxonIcons.Interceptor)
         )
     }
 
@@ -140,7 +140,7 @@ class CommandHandlerMethodLineMarkerProviderTest : AbstractAxonFixtureTestCase()
 
         assertThat(hasLineMarker(CommandHandlerMethodLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(CommandHandlerMethodLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("Saga: test", null, AxonIcons.Publisher)
+            OptionSummary("MySaga.handleSagaEvent(MySagaTriggeringEvent):${actualLineNumber(7)}", null, AxonIcons.Publisher)
         )
     }
 
@@ -175,7 +175,7 @@ class CommandHandlerMethodLineMarkerProviderTest : AbstractAxonFixtureTestCase()
 
         assertThat(hasLineMarker(CommandHandlerMethodLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(CommandHandlerMethodLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("Saga: test", null, AxonIcons.Publisher)
+            OptionSummary("MySaga.handleSagaEvent(MySagaTriggeringEvent):${actualLineNumber(5)}", null, AxonIcons.Publisher)
         )
     }
 }

--- a/src/test/kotlin/org/axonframework/intellij/ide/plugin/markers/handlers/CommandInterceptorLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/axonframework/intellij/ide/plugin/markers/handlers/CommandInterceptorLineMarkerProviderTest.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022. Axon Framework
+ *  Copyright (c) (2010-2022). Axon Framework
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ class CommandInterceptorLineMarkerProviderTest : AbstractAxonFixtureTestCase() {
         )
         assertThat(hasLineMarker(CommandInterceptorLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(CommandInterceptorLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("MyCommand", "MyAggregate", AxonIcons.Handler)
+            OptionSummary("MyAggregate.handle(MyCommand)", "MyAggregate", AxonIcons.Handler)
         )
     }
 
@@ -84,7 +84,7 @@ class CommandInterceptorLineMarkerProviderTest : AbstractAxonFixtureTestCase() {
         )
         assertThat(hasLineMarker(CommandInterceptorLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(CommandInterceptorLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("MyCommand", "MyAggregate", AxonIcons.Handler)
+            OptionSummary("MyAggregate.handle(MyCommand)", "MyAggregate", AxonIcons.Handler)
         )
     }
 
@@ -109,7 +109,7 @@ class CommandInterceptorLineMarkerProviderTest : AbstractAxonFixtureTestCase() {
         )
         assertThat(hasLineMarker(CommandInterceptorLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(CommandInterceptorLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("MyCommand", "MyAggregate", AxonIcons.Handler)
+            OptionSummary("MyAggregate.handle(MyCommand)", "MyAggregate", AxonIcons.Handler)
         )
     }
 
@@ -139,7 +139,7 @@ class CommandInterceptorLineMarkerProviderTest : AbstractAxonFixtureTestCase() {
         )
         assertThat(hasLineMarker(CommandInterceptorLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(CommandInterceptorLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("MyCommand", "MyEntity", AxonIcons.Handler)
+            OptionSummary("MyEntity.handle(MyCommand)", "MyEntity", AxonIcons.Handler)
         )
     }
 }

--- a/src/test/kotlin/org/axonframework/intellij/ide/plugin/markers/handlers/CommonHandlerMethodLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/axonframework/intellij/ide/plugin/markers/handlers/CommonHandlerMethodLineMarkerProviderTest.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022. Axon Framework
+ *  Copyright (c) (2010-2022). Axon Framework
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ class CommonHandlerMethodLineMarkerProviderTest : AbstractAxonFixtureTestCase() 
 
         assertThat(hasLineMarker(CommonHandlerMethodLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(CommonHandlerMethodLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("MyCommand", null, AxonIcons.Publisher)
+            OptionSummary("MyAggregate.handle(MyCommand):${actualLineNumber(7)}", null, AxonIcons.Publisher)
         )
     }
 
@@ -81,7 +81,7 @@ class CommonHandlerMethodLineMarkerProviderTest : AbstractAxonFixtureTestCase() 
 
         assertThat(hasLineMarker(CommonHandlerMethodLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(CommonHandlerMethodLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("MyCommand", null, AxonIcons.Publisher)
+            OptionSummary("MyAggregate.handle(MyCommand):${actualLineNumber(5)}", null, AxonIcons.Publisher)
         )
     }
 
@@ -109,7 +109,7 @@ class CommonHandlerMethodLineMarkerProviderTest : AbstractAxonFixtureTestCase() 
 
         assertThat(hasLineMarker(CommonHandlerMethodLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(CommonHandlerMethodLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("EventSourcingHandler MyAggregate", null, AxonIcons.Publisher)
+            OptionSummary("MyAggregate.handle(MyEventOne):${actualLineNumber(9)}", null, AxonIcons.Publisher)
         )
     }
 
@@ -142,7 +142,7 @@ class CommonHandlerMethodLineMarkerProviderTest : AbstractAxonFixtureTestCase() 
 
         assertThat(hasLineMarker(CommonHandlerMethodLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(CommonHandlerMethodLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("EventSourcingHandler MyAggregate", null, AxonIcons.Publisher)
+            OptionSummary("MyAggregate.handle(MyEventOne):${actualLineNumber(6)}", null, AxonIcons.Publisher)
         )
     }
 
@@ -170,7 +170,7 @@ class CommonHandlerMethodLineMarkerProviderTest : AbstractAxonFixtureTestCase() 
 
         assertThat(hasLineMarker(CommonHandlerMethodLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(CommonHandlerMethodLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("MyCommand", null, AxonIcons.Publisher)
+            OptionSummary("MyAggregate.handle(MyCommand):${actualLineNumber(14)}", null, AxonIcons.Publisher)
         )
     }
 
@@ -210,7 +210,7 @@ class CommonHandlerMethodLineMarkerProviderTest : AbstractAxonFixtureTestCase() 
 
         assertThat(hasLineMarker(CommonHandlerMethodLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(CommonHandlerMethodLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("MyCommand", null, AxonIcons.Publisher)
+            OptionSummary("MyAggregate.handle(MyCommand):${actualLineNumber(7)}", null, AxonIcons.Publisher)
         )
     }
 
@@ -239,7 +239,7 @@ class CommonHandlerMethodLineMarkerProviderTest : AbstractAxonFixtureTestCase() 
 
         assertThat(hasLineMarker(CommonHandlerMethodLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(CommonHandlerMethodLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("MyCommand", null, AxonIcons.Publisher)
+            OptionSummary("MyAggregate.handle(MyCommand):${actualLineNumber(14)}", null, AxonIcons.Publisher)
         )
     }
 }

--- a/src/test/kotlin/org/axonframework/intellij/ide/plugin/markers/handlers/DeadlineHandlerMethodLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/axonframework/intellij/ide/plugin/markers/handlers/DeadlineHandlerMethodLineMarkerProviderTest.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022. Axon Framework
+ *  Copyright (c) (2010-2022). Axon Framework
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ class DeadlineHandlerMethodLineMarkerProviderTest : AbstractAxonFixtureTestCase(
         )
         assertThat(hasLineMarker(DeadlineHandlerMethodLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(DeadlineHandlerMethodLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("MyCommand", null, AxonIcons.Publisher)
+            OptionSummary("MyAggregate.handle(MyCommand, DeadlineManager):${actualLineNumber(9)}", "my_special_deadline", AxonIcons.Publisher)
         )
     }
 }

--- a/src/test/kotlin/org/axonframework/intellij/ide/plugin/markers/publishers/DeadlinePublisherLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/axonframework/intellij/ide/plugin/markers/publishers/DeadlinePublisherLineMarkerProviderTest.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022. Axon Framework
+ *  Copyright (c) (2010-2022). Axon Framework
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -140,7 +140,7 @@ class DeadlinePublisherLineMarkerProviderTest : AbstractAxonFixtureTestCase() {
         )
         assertThat(hasLineMarker(DeadlinePublisherLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(DeadlinePublisherLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("Deadline my_special_deadline", null, AxonIcons.Handler)
+            OptionSummary("MyAggregate.handle()", null, AxonIcons.Handler)
         )
     }
 
@@ -164,7 +164,7 @@ class DeadlinePublisherLineMarkerProviderTest : AbstractAxonFixtureTestCase() {
         )
         assertThat(hasLineMarker(DeadlinePublisherLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(DeadlinePublisherLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("Deadline my_special_deadline", null, AxonIcons.Handler)
+            OptionSummary("MyAggregate.handle()", null, AxonIcons.Handler)
         )
     }
 }

--- a/src/test/kotlin/org/axonframework/intellij/ide/plugin/markers/publishers/PublishMethodLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/axonframework/intellij/ide/plugin/markers/publishers/PublishMethodLineMarkerProviderTest.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022. Axon Framework
+ *  Copyright (c) (2010-2022). Axon Framework
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ class PublishMethodLineMarkerProviderTest : AbstractAxonFixtureTestCase() {
 
         assertThat(hasLineMarker(PublishMethodLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(PublishMethodLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("EventSourcingHandler MyAggregate", null, AxonIcons.Handler)
+            OptionSummary("MyAggregate.handle(MyEvent)", "EventSourcingHandler", AxonIcons.Handler)
         )
     }
 
@@ -76,7 +76,7 @@ class PublishMethodLineMarkerProviderTest : AbstractAxonFixtureTestCase() {
 
         assertThat(hasLineMarker(PublishMethodLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(PublishMethodLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("EventSourcingHandler MyAggregate", null, AxonIcons.Handler)
+            OptionSummary("MyAggregate.handle(MyEvent)", "EventSourcingHandler", AxonIcons.Handler)
         )
     }
 
@@ -103,7 +103,7 @@ class PublishMethodLineMarkerProviderTest : AbstractAxonFixtureTestCase() {
 
         assertThat(hasLineMarker(PublishMethodLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(PublishMethodLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("MyCommand", "MyAggregate", AxonIcons.Handler)
+            OptionSummary("MyAggregate.handle(MyCommand)", "MyAggregate", AxonIcons.Handler)
         )
     }
 
@@ -127,7 +127,7 @@ class PublishMethodLineMarkerProviderTest : AbstractAxonFixtureTestCase() {
 
         assertThat(hasLineMarker(PublishMethodLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(PublishMethodLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("MyCommand", "MyAggregate", AxonIcons.Handler)
+            OptionSummary("MyAggregate.handle(MyCommand)", "MyAggregate", AxonIcons.Handler)
         )
     }
 
@@ -152,7 +152,7 @@ class PublishMethodLineMarkerProviderTest : AbstractAxonFixtureTestCase() {
 
         assertThat(hasLineMarker(PublishMethodLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(PublishMethodLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("MyProcessingGroup.handle", "some-group", AxonIcons.Handler)
+            OptionSummary("MyProcessingGroup.handle(MyQuery)", "some-group", AxonIcons.Handler)
         )
     }
 
@@ -175,7 +175,7 @@ class PublishMethodLineMarkerProviderTest : AbstractAxonFixtureTestCase() {
 
         assertThat(hasLineMarker(PublishMethodLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(PublishMethodLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("MyProcessingGroup.handle", "test", AxonIcons.Handler)
+            OptionSummary("MyProcessingGroup.handle(MyQuery)", "test", AxonIcons.Handler)
         )
     }
 
@@ -201,7 +201,7 @@ class PublishMethodLineMarkerProviderTest : AbstractAxonFixtureTestCase() {
 
         assertThat(hasLineMarker(PublishMethodLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(PublishMethodLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("MyProcessingGroup", "awesome-group", AxonIcons.Handler)
+            OptionSummary("MyProcessingGroup.handle(MyEvent)", "awesome-group", AxonIcons.Handler)
         )
     }
 
@@ -226,7 +226,7 @@ class PublishMethodLineMarkerProviderTest : AbstractAxonFixtureTestCase() {
 
         assertThat(hasLineMarker(PublishMethodLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(PublishMethodLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("MyProcessingGroup", "test", AxonIcons.Handler)
+            OptionSummary("MyProcessingGroup.handle(MyEvent)", "test", AxonIcons.Handler)
         )
     }
 
@@ -273,7 +273,7 @@ class PublishMethodLineMarkerProviderTest : AbstractAxonFixtureTestCase() {
 
         assertThat(hasLineMarker(PublishMethodLineMarkerProvider::class.java)).isTrue
         assertThat(getLineMarkerOptions(PublishMethodLineMarkerProvider::class.java)).containsExactly(
-            OptionSummary("MyProcessingGroup", "test", AxonIcons.Handler)
+            OptionSummary("MyProcessingGroup.handle(MyBuilderBasedEvent)", "test", AxonIcons.Handler)
         )
     }
 }


### PR DESCRIPTION
Remove the link between creators and parent handlers since they were odd to some customers.
References now show the method signature (and sometimes line number).