### PR TITLE
Implement recursion guard for aggregate inspection

### DIFF
--- a/src/test/kotlin/org/axonframework/intellij/ide/plugin/markers/ClassLineMarkerProviderTest.kt
+++ b/src/test/kotlin/org/axonframework/intellij/ide/plugin/markers/ClassLineMarkerProviderTest.kt
@@ -102,6 +102,28 @@ class ClassLineMarkerProviderTest : AbstractAxonFixtureTestCase() {
         )
     }
 
+    fun `test shows line marker on aggregate of hierarchy when recursive`() {
+        addFile(
+            "MyAggregate.kt", """
+            class RecursiveAggregateMember {
+                @AggregateMember
+                private var subItems: List<RecursiveAggregateMember>
+            }
+            
+            @AggregateRoot
+            class MyAggregate {<caret>
+                @AggregateMember
+                private lateinit var singleMember: RecursiveAggregateMember
+            }
+        """.trimIndent(), open = true
+        )
+        Assertions.assertThat(hasLineMarker(ClassLineMarkerProvider::class.java)).isTrue
+        Assertions.assertThat(getLineMarkerOptions(ClassLineMarkerProvider::class.java)).containsExactly(
+            OptionSummary("MyAggregate", null, AxonIcons.Axon),
+            OptionSummary("- RecursiveAggregateMember", null, AxonIcons.Axon),
+        )
+    }
+
     fun `test shows line marker on child of hierarchy`() {
         addFile(
             "MyAggregate.kt", """


### PR DESCRIPTION
Fixes #261 by checking if a class was already encountered in the hierarchy to prevent recursion. As ultimate safeguard, a depth was added. We will never scan deeper than ~20 levels of aggregate hierarchy any longer. 