### PR TITLE
Migrate to plugin v2 and fix compatibility with new EAP IDEA version …

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
             -   name: Verify plugin
                 uses: gradle/gradle-build-action@v2.9.0
                 with:
-                    arguments: runPluginVerifier
+                    arguments: verifyPlugin
 
             -   name: Publish plugin
                 uses: gradle/gradle-build-action@v2.9.0

--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -15,3 +15,6 @@ jobs:
         uses: JetBrains/qodana-action@v2023.2.8
         with:
           linter: jetbrains/qodana-jvm-community
+      - uses: github/codeql-action/upload-sarif@v2
+        with:
+            sarif_file: ${{ runner.temp }}/qodana/results/qodana.sarif.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
             -   name: Verify plugin
                 uses: gradle/gradle-build-action@v2.9.0
                 with:
-                    arguments: runPluginVerifier
+                    arguments: verifyPlugin
 concurrency:
     group: ${{github.workflow}}-${{github.head_ref || github.run_id }}
     cancel-in-progress: true

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 ## Directory-based project format
 .idea/
+.intellijPlatform
 # if you remove the above rule, at least ignore user-specific stuff:
 # .idea/workspace.xml
 # .idea/tasks.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [0.8.8]
 - Plugin is now compatible with IDEA 2024.3 (IDEA 243.*) with minimum version of 2024.2
+- Fix various deprecation warnings
+- Fix various javadoc issues
 
 ## [0.8.7]
 - Plugin is now compatible with IDEA 2024.2 (IDEA 242.*)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # Axon Framework plugin Changelog
 
+## [0.8.8]
+- Plugin is now compatible with IDEA 2024.3 (IDEA 243.*) with minimum version of 2024.2
+
 ## [0.8.7]
 - Plugin is now compatible with IDEA 2024.2 (IDEA 242.*)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,6 +90,12 @@ intellijPlatform {
                 untilBuild = properties("pluginUntilBuild")
             }
         }
+
+        freeArgs = listOf(
+            "-mute TemplateWordInPluginId"
+        )
+
+
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,9 @@
  *  limitations under the License.
  */
 
+import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
+import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 fun properties(key: String) = project.findProperty(key).toString()
@@ -25,9 +27,9 @@ plugins {
     // Kotlin support
     id("org.jetbrains.kotlin.jvm") version "1.9.10"
     // Gradle IntelliJ Plugin
-    id("org.jetbrains.intellij") version "1.16.0"
+    id("org.jetbrains.intellij.platform") version "2.1.0"
     // Gradle Changelog Plugin
-    id("org.jetbrains.changelog") version "2.2.0"
+    id("org.jetbrains.changelog") version "2.2.1"
     // Gradle Qodana Plugin
     id("org.jetbrains.qodana") version "0.1.13"
 }
@@ -35,19 +37,48 @@ plugins {
 group = properties("pluginGroup")
 version = properties("pluginVersion")
 
-// Configure project's dependencies
-repositories {
-    mavenCentral()
-}
 
-// Configure Gradle IntelliJ Plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
-intellij {
-    pluginName.set(properties("pluginName"))
-    version.set(properties("platformVersion"))
-    type.set(properties("platformType"))
+intellijPlatform {
+    pluginConfiguration {
+        name = properties("pluginName")
+        version = properties("pluginVersion")
+        ideaVersion {
+            sinceBuild = properties("pluginSinceBuild")
+            untilBuild = properties("pluginUntilBuild")
+        }
 
-    // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
-    plugins.set(properties("platformPlugins").split(',').map(String::trim).filter(String::isNotEmpty))
+
+        description = projectDir.resolve("README.md").readText().lines().run {
+            val start = "<!-- Plugin description -->"
+            val end = "<!-- Plugin description end -->"
+            if (!containsAll(listOf(start, end))) {
+                throw GradleException("Plugin description section not found in README.md:\n$start ... $end")
+            }
+            subList(indexOf(start) + 1, indexOf(end))
+        }.joinToString("\n").run { markdownToHTML(this) }
+
+        changeNotes = provider {
+            changelog.renderItem(
+                changelog
+                    .get(properties("pluginVersion"))
+                    .withHeader(false)
+                    .withEmptySections(false),
+                Changelog.OutputType.HTML
+            )
+        }
+    }
+
+    publishing {
+        token = System.getenv("PUBLISH_TOKEN")
+        channels = listOf("default")
+    }
+
+    signing {
+        certificateChain = System.getenv("CERTIFICATE_CHAIN")
+        privateKey = System.getenv("PRIVATE_KEY")
+        password = System.getenv("PRIVATE_KEY_PASSWORD")
+    }
+
 }
 
 // Configure Gradle Changelog Plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
@@ -76,59 +107,6 @@ tasks {
         }
     }
 
-    wrapper {
-        gradleVersion = properties("gradleVersion")
-    }
-
-    patchPluginXml {
-        version.set(properties("pluginVersion"))
-        sinceBuild.set(properties("pluginSinceBuild"))
-        untilBuild.set(properties("pluginUntilBuild"))
-
-        // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
-        pluginDescription.set(
-            projectDir.resolve("README.md").readText().lines().run {
-                val start = "<!-- Plugin description -->"
-                val end = "<!-- Plugin description end -->"
-
-                if (!containsAll(listOf(start, end))) {
-                    throw GradleException("Plugin description section not found in README.md:\n$start ... $end")
-                }
-                subList(indexOf(start) + 1, indexOf(end))
-            }.joinToString("\n").run { markdownToHTML(this) }
-        )
-
-        // Get the latest available change notes from the changelog file
-        changeNotes.set(provider {
-            changelog.run {
-                getOrNull(properties("pluginVersion")) ?: getLatest()
-            }.toHTML()
-        })
-    }
-
-    // Configure UI tests plugin
-    // Read more: https://github.com/JetBrains/intellij-ui-test-robot
-    runIdeForUiTests {
-        systemProperty("robot-server.port", "8082")
-        systemProperty("ide.mac.message.dialogs.as.sheets", "false")
-        systemProperty("jb.privacy.policy.text", "<!--999.999-->")
-        systemProperty("jb.consents.confirmation.enabled", "false")
-    }
-
-    signPlugin {
-        certificateChain.set(System.getenv("CERTIFICATE_CHAIN"))
-        privateKey.set(System.getenv("PRIVATE_KEY"))
-        password.set(System.getenv("PRIVATE_KEY_PASSWORD"))
-    }
-
-    publishPlugin {
-        dependsOn("patchChangelog")
-        token.set(System.getenv("PUBLISH_TOKEN"))
-        // pluginVersion is based on the SemVer (https://semver.org) and supports pre-release labels, like 2.1.7-alpha.3
-        // Specify pre-release label to publish the plugin in a custom Release Channel automatically. Read more:
-        // https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel
-        channels.set(listOf(properties("pluginVersion").split('-').getOrElse(1) { "default" }.split('.').first()))
-    }
     runIde {
         jvmArgs("-Xmx2G")
     }
@@ -140,11 +118,31 @@ tasks {
 }
 
 dependencies {
+    intellijPlatform {
+        intellijIdeaCommunity(properties("platformVersion"))
+        bundledPlugin("com.intellij.java")
+        bundledPlugin("org.jetbrains.kotlin")
+        pluginVerifier()
+        zipSigner()
+        instrumentationTools()
+
+        testFramework(TestFrameworkType.Plugin.Java)
+    }
+
     implementation("io.sentry:sentry:6.32.0")
 
+    testImplementation("junit:junit:4.13.2")
     testImplementation("org.axonframework:axon-modelling:${properties("axonVersion")}")
     testImplementation("org.axonframework:axon-messaging:${properties("axonVersion")}")
     testImplementation("org.axonframework:axon-eventsourcing:${properties("axonVersion")}")
     testImplementation("org.axonframework:axon-configuration:${properties("axonVersion")}")
     testImplementation("org.assertj:assertj-core:3.24.2")
+}
+
+// Configure project's dependencies
+repositories {
+    mavenCentral()
+    intellijPlatform {
+        defaultRepositories()
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,9 @@
 
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
+import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+import org.jetbrains.intellij.platform.gradle.models.ProductRelease
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 fun properties(key: String) = project.findProperty(key).toString()
@@ -79,6 +81,16 @@ intellijPlatform {
         password = System.getenv("PRIVATE_KEY_PASSWORD")
     }
 
+    pluginVerification {
+        ides {
+            select {
+                types = listOf(IntelliJPlatformType.IntellijIdeaCommunity)
+                channels = listOf(ProductRelease.Channel.RELEASE, ProductRelease.Channel.EAP)
+                sinceBuild = properties("pluginSinceBuild")
+                untilBuild = properties("pluginUntilBuild")
+            }
+        }
+    }
 }
 
 // Configure Gradle Changelog Plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,7 +92,8 @@ intellijPlatform {
         }
 
         freeArgs = listOf(
-            "-mute TemplateWordInPluginId"
+            // Mute some inspections that should be ignored (as we already uploaded and the id can't be changed)
+            "-mute", "TemplateWordInPluginId,ForbiddenPluginIdPrefix"
         )
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,32 +14,18 @@
 #  limitations under the License.
 #
 
-# IntelliJ Platform Artifacts Repositories
-# -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 
+# Basic plugin information
 pluginGroup=io.axoniq.ide.intellij
 pluginName=Axon Framework
-pluginVersion=0.8.7
-axonVersion=4.9.0
-
-# See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-# for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 232
-pluginUntilBuild = 242.*
-
-# IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
-platformType = IC
-platformVersion = 2024.1
-
-# Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
-# Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins =com.intellij.java,org.jetbrains.kotlin
-
-# Java language level used to compile sources and to generate the files for - Java 11 is required since 2020.3
+pluginVersion=0.8.8
+axonVersion=4.10.1
 javaVersion = 17
 
-# Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion = 7.3
+# Define the plugin version range. This is used to determine the compatibility of the plugin with the IDE.
+pluginSinceBuild = 242
+pluginUntilBuild = 243.*
+platformVersion = 2024.2
 
 # Opt-out flag for bundling Kotlin standard library.
 # See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/api/AxonAnnotation.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/api/AxonAnnotation.kt
@@ -25,6 +25,7 @@ enum class AxonAnnotation(val annotationName: String) {
     EVENT_SOURCING_HANDLER("org.axonframework.eventsourcing.EventSourcingHandler"),
     QUERY_HANDLER("org.axonframework.queryhandling.QueryHandler"),
     COMMAND_HANDLER_INTERCEPTOR("org.axonframework.modelling.command.CommandHandlerInterceptor"),
+    MESSAGE_HANDLER_INTERCEPTOR("org.axonframework.messaging.interceptors.MessageHandlerInterceptor"),
     SAGA_EVENT_HANDLER("org.axonframework.modelling.saga.SagaEventHandler"),
     DEADLINE_HANDLER("org.axonframework.deadline.annotation.DeadlineHandler"),
     RESET_HANDLER("org.axonframework.eventhandling.ResetHandler"),

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/api/Handler.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/api/Handler.kt
@@ -25,7 +25,7 @@ import javax.swing.Icon
  * Parent interface of any Handler, providing methods to describe the handler in interface elements.
  *
  * @see org.axonframework.intellij.ide.plugin.resolving.MessageHandlerResolver
- * @see org.axonframework.intellij.ide.plugin.handlers.searchers.AbstractHandlerSearcher
+ * @see org.axonframework.intellij.ide.plugin.resolving.handlers.types.AbstractHandlerSearcher
  */
 interface Handler : PsiElementWrapper {
     /**

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/api/Handler.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/api/Handler.kt
@@ -25,7 +25,7 @@ import javax.swing.Icon
  * Parent interface of any Handler, providing methods to describe the handler in interface elements.
  *
  * @see org.axonframework.intellij.ide.plugin.resolving.MessageHandlerResolver
- * @see org.axonframework.intellij.ide.plugin.resolving.handlers.types.AbstractHandlerSearcher
+ * @see org.axonframework.intellij.ide.plugin.resolving.handlers.searchers.AbstractHandlerSearcher
  */
 interface Handler : PsiElementWrapper {
     /**

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/api/MessageHandlerType.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/api/MessageHandlerType.kt
@@ -43,7 +43,7 @@ enum class MessageHandlerType(
             if (annotationName == null) {
                 return false
             }
-            return values().any { type -> type.annotationName == annotationName }
+            return entries.any { type -> type.annotationName == annotationName }
         }
     }
 }

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/markers/publishers/DeadlinePublisherLineMarkerProvider.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/markers/publishers/DeadlinePublisherLineMarkerProvider.kt
@@ -48,7 +48,6 @@ import org.jetbrains.uast.toUElementOfType
  *
  * @see DeadlineHandler
  * @see org.axonframework.intellij.ide.plugin.resolving.DeadlineManagerMethodResolver
- * @see org.axonframework.intellij.ide.plugin.creators.searchers.DeadlineMessageCreatorSearcher
  */
 class DeadlinePublisherLineMarkerProvider : LineMarkerProvider {
     override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? {

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/AnnotationResolver.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/AnnotationResolver.kt
@@ -78,7 +78,7 @@ class AnnotationResolver(val project: Project) {
             .firstOrNull { it.value.any { annClass -> annClass.psiClass.qualifiedName == qualifiedName } }
             ?.key
             ?: return null
-        return MessageHandlerType.values().firstOrNull { it.annotation == annotation }
+        return MessageHandlerType.entries.firstOrNull { it.annotation == annotation }
     }
 
     /**
@@ -108,7 +108,7 @@ class AnnotationResolver(val project: Project) {
      */
     private fun computeAnnotations(): Map<AxonAnnotation, List<ResolvedAnnotation>> {
         val libAnnotations = libraryAnnotationCache.getLibraryAnnotations()
-        return AxonAnnotation.values().associateWith { axonAnn ->
+        return AxonAnnotation.entries.associateWith { axonAnn ->
             val specificLibAnnotations = libAnnotations.filter { axonAnn == it.axonAnnotation }
             specificLibAnnotations.flatMap { descAnn ->
                 scanDescendants(axonAnn, descAnn, project.axonScope())
@@ -175,7 +175,7 @@ class AnnotationResolver(val project: Project) {
         }
 
         private fun updateLibraryAnnotations() {
-            libraryAnnotations = AxonAnnotation.values().flatMap { scanAnnotation(it, project.allScope()) }
+            libraryAnnotations = AxonAnnotation.entries.flatMap { scanAnnotation(it, project.allScope()) }
             libraryInitialized = true
         }
     }

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/searchers/CommandHandlerInterceptorSearcher.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/searchers/CommandHandlerInterceptorSearcher.kt
@@ -29,7 +29,7 @@ import org.axonframework.intellij.ide.plugin.util.toQualifiedName
 /**
  * Searches for any command interceptors. Currently, limited to Aggregates only.
  *
- * @see org.axonframework.intellij.ide.plugin.handlers.types.CommandHandlerInterceptor
+ * @see org.axonframework.intellij.ide.plugin.resolving.handlers.types.CommandHandlerInterceptor
  */
 class CommandHandlerInterceptorSearcher : AbstractHandlerSearcher(MessageHandlerType.COMMAND_INTERCEPTOR) {
     override fun createMessageHandler(method: PsiMethod, annotation: PsiClass?): Handler? {

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/searchers/CommandHandlerSearcher.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/searchers/CommandHandlerSearcher.kt
@@ -28,7 +28,7 @@ import org.axonframework.intellij.ide.plugin.util.toQualifiedName
 /**
  * Searches for any command handlers
  *
- * @see org.axonframework.intellij.ide.plugin.handlers.types.CommandHandler
+ * @see org.axonframework.intellij.ide.plugin.resolving.handlers.types.CommandHandler
  */
 class CommandHandlerSearcher : AbstractHandlerSearcher(MessageHandlerType.COMMAND) {
     override fun createMessageHandler(method: PsiMethod, annotation: PsiClass?): Handler? {

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/searchers/DeadlineHandlerSearcher.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/searchers/DeadlineHandlerSearcher.kt
@@ -31,7 +31,7 @@ import org.axonframework.intellij.ide.plugin.util.toQualifiedName
  * If there is not payload specific, the payload is java.lang.Object as fallback.
  * In addition, deadline handlers have a name.
  *
- * @see org.axonframework.intellij.ide.plugin.handlers.types.DeadlineHandler
+ * @see org.axonframework.intellij.ide.plugin.resolving.handlers.types.DeadlineHandler
  */
 class DeadlineHandlerSearcher : AbstractHandlerSearcher(MessageHandlerType.DEADLINE) {
     override fun createMessageHandler(method: PsiMethod, annotation: PsiClass?): Handler {

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/searchers/EventHandlerSearcher.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/searchers/EventHandlerSearcher.kt
@@ -28,7 +28,7 @@ import org.axonframework.intellij.ide.plugin.util.toQualifiedName
 /**
  * Searches for any event handlers that are not part of the aggregate model.
  *
- * @see org.axonframework.intellij.ide.plugin.handlers.types.EventHandler
+ * @see org.axonframework.intellij.ide.plugin.resolving.handlers.types.EventHandler
  */
 class EventHandlerSearcher : AbstractHandlerSearcher(MessageHandlerType.EVENT) {
     override fun createMessageHandler(method: PsiMethod, annotation: PsiClass?): Handler? {

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/searchers/EventSourcingHandlerSearcher.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/searchers/EventSourcingHandlerSearcher.kt
@@ -28,7 +28,7 @@ import org.axonframework.intellij.ide.plugin.util.toQualifiedName
 /**
  * Searches for any event handlers in aggregates that source the state of the aggregates.
  *
- * @see org.axonframework.intellij.ide.plugin.handlers.types.EventSourcingHandler
+ * @see org.axonframework.intellij.ide.plugin.resolving.handlers.types.EventSourcingHandler
  */
 class EventSourcingHandlerSearcher : AbstractHandlerSearcher(MessageHandlerType.EVENT_SOURCING) {
     override fun createMessageHandler(method: PsiMethod, annotation: PsiClass?): Handler? {

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/searchers/QueryHandlerSearcher.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/searchers/QueryHandlerSearcher.kt
@@ -28,7 +28,7 @@ import org.axonframework.intellij.ide.plugin.util.toQualifiedName
 /**
  * Searches for any query handlers.
  *
- * @see org.axonframework.intellij.ide.plugin.handlers.types.QueryHandler
+ * @see org.axonframework.intellij.ide.plugin.resolving.handlers.types.QueryHandler
  */
 class QueryHandlerSearcher : AbstractHandlerSearcher(MessageHandlerType.QUERY) {
     override fun createMessageHandler(method: PsiMethod, annotation: PsiClass?): Handler? {

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/searchers/SagaEventHandlerSearcher.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/searchers/SagaEventHandlerSearcher.kt
@@ -28,7 +28,7 @@ import org.axonframework.intellij.ide.plugin.util.toQualifiedName
 /**
  * Searches for any saga event handlers.
  *
- * @see org.axonframework.intellij.ide.plugin.handlers.types.SagaEventHandler
+ * @see org.axonframework.intellij.ide.plugin.resolving.handlers.types.SagaEventHandler
  */
 class SagaEventHandlerSearcher : AbstractHandlerSearcher(MessageHandlerType.SAGA) {
     override fun createMessageHandler(method: PsiMethod, annotation: PsiClass?): Handler? {

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/types/AggregateConstructor.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/types/AggregateConstructor.kt
@@ -26,7 +26,7 @@ import org.axonframework.intellij.ide.plugin.util.toShortName
  * Represents a constructor invocation of an Aggregate.
  * This is often done during command handling, where aggregate A creates an instance of aggregate B.
  *
- * @see org.axonframework.intellij.ide.plugin.handlers.searchers.AggregateConstructorSearcher
+ * @see org.axonframework.intellij.ide.plugin.resolving.handlers.searchers.AggregateConstructorSearcher
  */
 data class AggregateConstructor(
     override val element: PsiMethod,

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/types/CommandHandler.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/types/CommandHandler.kt
@@ -26,7 +26,7 @@ import org.axonframework.intellij.ide.plugin.util.toShortName
  * Represents a method being able to handle a command.
  *
  * @param componentName The fully qualified name of the class handling the command.
- * @See org.axonframework.intellij.ide.plugin.handlers.searchers.CommandHandlerSearcher
+ * @See org.axonframework.intellij.ide.plugin.resolving.handlers.searchers.CommandHandlerSearcher
  */
 data class CommandHandler(
     override val element: PsiMethod,

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/types/CommandHandlerInterceptor.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/types/CommandHandlerInterceptor.kt
@@ -28,7 +28,7 @@ import javax.swing.Icon
  * Represents a method that is able to intercept a command.
  *
  * @param componentName The fully qualified name of the class intercepting the command
- * @see org.axonframework.intellij.ide.plugin.handlers.searchers.CommandHandlerInterceptorSearcher
+ * @see org.axonframework.intellij.ide.plugin.resolving.handlers.searchers.CommandHandlerInterceptorSearcher
  */
 data class CommandHandlerInterceptor(
     override val element: PsiMethod,

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/types/DeadlineHandler.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/types/DeadlineHandler.kt
@@ -24,7 +24,7 @@ import org.axonframework.intellij.ide.plugin.api.MessageHandlerType
 /**
  * Represents a method being able to a deadline message. Invoked when a deadline expires.
  *
- * @See org.axonframework.intellij.ide.plugin.handlers.searchers.DeadlineHandlerSearcher
+ * @See org.axonframework.intellij.ide.plugin.resolving.handlers.searchers.DeadlineHandlerSearcher
  */
 data class DeadlineHandler(
     override val element: PsiMethod,

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/types/EventHandler.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/types/EventHandler.kt
@@ -29,7 +29,7 @@ import org.axonframework.intellij.ide.plugin.util.containingClassname
  *
  * @param processingGroup The name of the component handling the event, based on package or ProcessingGroup annotation
  *
- * @See org.axonframework.intellij.ide.plugin.handlers.searchers.EventHandlerSearcher
+ * @See org.axonframework.intellij.ide.plugin.resolving.handlers.searchers.EventHandlerSearcher
  * @see SagaEventHandler
  * @see EventSourcingHandler
  */

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/types/EventSourcingHandler.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/types/EventSourcingHandler.kt
@@ -26,7 +26,7 @@ import org.axonframework.intellij.ide.plugin.util.toShortName
  * Represents a method being able to handle an event for sourcing an aggregate.
  *
  * @param entity The fully qualified name of the aggregate class sourced by the event
- * @See org.axonframework.intellij.ide.plugin.handlers.searchers.EventSourcingHandlerSearcher
+ * @See org.axonframework.intellij.ide.plugin.resolving.handlers.searchers.EventSourcingHandlerSearcher
  */
 data class EventSourcingHandler(
     override val element: PsiMethod,

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/types/QueryHandler.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/types/QueryHandler.kt
@@ -26,7 +26,7 @@ import org.axonframework.intellij.ide.plugin.util.containingClassname
  * Represents a method being able to handle a query.
  *
  * @param componentName The name of the component handling the event, based on package or ProcessingGroup annotation
- * @See org.axonframework.intellij.ide.plugin.handlers.searchers.QueryHandlerSearcher
+ * @See org.axonframework.intellij.ide.plugin.resolving.handlers.searchers.QueryHandlerSearcher
  */
 data class QueryHandler(
     override val element: PsiMethod,

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/types/SagaEventHandler.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/resolving/handlers/types/SagaEventHandler.kt
@@ -25,7 +25,7 @@ import org.axonframework.intellij.ide.plugin.api.MessageHandlerType
  * Represents a method in a Saga that is able to handle an event
  *
  * @param processingGroup The name of the saga handling the event, based on package or ProcessingGroup annotation
- * @See org.axonframework.intellij.ide.plugin.handlers.searchers.SagaEventHandlerSearcher
+ * @See org.axonframework.intellij.ide.plugin.resolving.handlers.searchers.SagaEventHandlerSearcher
  */
 data class SagaEventHandler(
     override val element: PsiMethod,

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/usage/AxonImplicitUsageProvider.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/usage/AxonImplicitUsageProvider.kt
@@ -76,7 +76,7 @@ class AxonImplicitUsageProvider : ImplicitUsageProvider {
     }
 
 
-    private fun UMethod.isAnnotatedWithAxon() = AxonAnnotation.values().any {
+    private fun UMethod.isAnnotatedWithAxon() = AxonAnnotation.entries.any {
         isAnnotated(it)
     }
 

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/usage/AxonVersionService.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/usage/AxonVersionService.kt
@@ -110,7 +110,7 @@ class AxonVersionService(val project: Project) {
     private fun extractVersion(name: String): AxonDependencyVersion? {
         val match = regex.find(name)!!
         val (moduleName, majorVersion, minorVersion, patchVersion, remaining) = match.destructured
-        val dependency = AxonDependency.values().firstOrNull { it.moduleName == moduleName } ?: return null
+        val dependency = AxonDependency.entries.firstOrNull { it.moduleName == moduleName } ?: return null
         return AxonDependencyVersion(dependency,
             Integer.parseInt(majorVersion),
             Integer.parseInt(minorVersion),


### PR DESCRIPTION
…(2024.3)

This has been done following the migration guide. Everything seems to work correctly. Some parts (like signing of release) can only be tested during the actual release. 