### PR TITLE
[#307] Axon plugin gives false highlights about non existing properties when they are defined in a superclass

### DIFF
--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/inspections/saga/JavaSagaAssociationPropertyInspection.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/inspections/saga/JavaSagaAssociationPropertyInspection.kt
@@ -49,7 +49,7 @@ class JavaSagaAssociationPropertyInspection : AbstractBaseJavaLocalInspectionToo
             return null
         val payload = method.resolvePayloadType() ?: return null
         val payloadClass = method.project.toClass(payload) ?: return null
-        if (payloadClass.hasAccessor(attribute)) {
+        if (payloadClass.hasAccessor(attribute, true)) {
             return null
         }
         val annotation = method.resolveAnnotation(AxonAnnotation.SAGA_EVENT_HANDLER) ?: return null

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/inspections/saga/KotlinSagaAssociationPropertyInspection.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/inspections/saga/KotlinSagaAssociationPropertyInspection.kt
@@ -59,7 +59,7 @@ class KotlinSagaAssociationPropertyInspection : AbstractKotlinInspection() {
                     return
                 val payload = method.resolvePayloadType() ?: return
                 val payloadClass = method.project.toClass(payload) ?: return
-                if (payloadClass.hasAccessor(attribute)) {
+                if (payloadClass.hasAccessor(attribute, true)) {
                     return
                 }
                 val annotation = method.resolveAnnotation(AxonAnnotation.SAGA_EVENT_HANDLER) ?: return

--- a/src/test/kotlin/org/axonframework/intellij/ide/plugin/inspections/saga/JavaSagaAssociationPropertyInspectionTest.kt
+++ b/src/test/kotlin/org/axonframework/intellij/ide/plugin/inspections/saga/JavaSagaAssociationPropertyInspectionTest.kt
@@ -73,7 +73,7 @@ class JavaSagaAssociationPropertyInspectionTest : AbstractAxonFixtureTestCase() 
         myFixture.openFileInEditor(file)
         val highlights = myFixture.doHighlighting(HighlightSeverity.WARNING)
         Assertions.assertThat(highlights).noneMatch {
-            it.text == "handle" && it.description.contains("The message does not declare a property")
+            it.description.contains("The message does not declare a property")
         }
     }
 
@@ -100,7 +100,40 @@ class JavaSagaAssociationPropertyInspectionTest : AbstractAxonFixtureTestCase() 
         myFixture.openFileInEditor(file)
         val highlights = myFixture.doHighlighting(HighlightSeverity.WARNING)
         Assertions.assertThat(highlights).noneMatch {
-            it.text == "handle" && it.description.contains("The message does not declare a property")
+            it.description.contains("The message does not declare a property")
+        }
+    }
+
+    fun `test should detect defined property in superclass`() {
+        addFile(
+            "MyBaseMessage.java", """
+            public abstract class MyBaseMessage {
+                String some;
+            }
+        """.trimIndent()
+        )
+        addFile(
+            "MyMessage.java", """
+            public class MyMessage extends test.MyBaseMessage {
+            }
+        """.trimIndent()
+        )
+        val file = addFile(
+            "MyHandler.java", """
+                import test.MyMessage;
+                
+            public class MyHandler {
+                @SagaEventHandler(associationProperty = "some")
+                public void handle(MyMessage message) {}
+            }
+        """.trimIndent()
+        )
+
+        myFixture.enableInspections(JavaSagaAssociationPropertyInspection())
+        myFixture.openFileInEditor(file)
+        val highlights = myFixture.doHighlighting(HighlightSeverity.WARNING)
+        Assertions.assertThat(highlights).noneMatch {
+            it.description.contains("The message does not declare a property")
         }
     }
 
@@ -129,7 +162,42 @@ class JavaSagaAssociationPropertyInspectionTest : AbstractAxonFixtureTestCase() 
         myFixture.openFileInEditor(file)
         val highlights = myFixture.doHighlighting(HighlightSeverity.WARNING)
         Assertions.assertThat(highlights).noneMatch {
-            it.text == "handle" && it.description.contains("The message does not declare a property")
+            it.description.contains("The message does not declare a property")
+        }
+    }
+
+    fun `test should detect defined getter in superclass`() {
+        addFile(
+            "MyBaseMessage.java", """
+            public abstract class MyBaseMessage {
+                String getSome() {
+                    return ""; 
+                }
+            }
+        """.trimIndent()
+        )
+        addFile(
+            "MyMessage.java", """
+            public class MyMessage extends test.MyBaseMessage {
+            }
+        """.trimIndent()
+        )
+        val file = addFile(
+            "MyHandler.java", """
+                import test.MyMessage;
+                
+            public class MyHandler {
+                @SagaEventHandler(associationProperty = "some")
+                public void handle(MyMessage message) {}
+            }
+        """.trimIndent()
+        )
+
+        myFixture.enableInspections(JavaSagaAssociationPropertyInspection())
+        myFixture.openFileInEditor(file)
+        val highlights = myFixture.doHighlighting(HighlightSeverity.WARNING)
+        Assertions.assertThat(highlights).noneMatch {
+            it.description.contains("The message does not declare a property")
         }
     }
 }

--- a/src/test/kotlin/org/axonframework/intellij/ide/plugin/inspections/saga/KotlinSagaAssociationPropertyInspectionTest.kt
+++ b/src/test/kotlin/org/axonframework/intellij/ide/plugin/inspections/saga/KotlinSagaAssociationPropertyInspectionTest.kt
@@ -57,7 +57,7 @@ class KotlinSagaAssociationPropertyInspectionTest : AbstractAxonFixtureTestCase(
         myFixture.openFileInEditor(file)
         val highlights = myFixture.doHighlighting(HighlightSeverity.WARNING)
         Assertions.assertThat(highlights).noneMatch {
-            it.text == "handle" && it.description.contains("The message does not declare a property")
+            it.description.contains("The message does not declare a property")
         }
     }
 
@@ -77,7 +77,29 @@ class KotlinSagaAssociationPropertyInspectionTest : AbstractAxonFixtureTestCase(
         myFixture.openFileInEditor(file)
         val highlights = myFixture.doHighlighting(HighlightSeverity.WARNING)
         Assertions.assertThat(highlights).noneMatch {
-            it.text == "handle" && it.description.contains("The message does not declare a property")
+            it.description.contains("The message does not declare a property")
+        }
+    }
+
+    fun `test detect defined property in superclass`() {
+        val file = addFile(
+            "file.kt", """
+                open class MyBaseMessage(open val some: String) 
+                
+                open class MyMessage() : MyBaseMessage("")
+                
+                class MyHandler {
+                    @SagaEventHandler(associationProperty = "some")
+                    fun handle(message: MyMessage) {}
+                }
+        """.trimIndent()
+        )
+
+        myFixture.enableInspections(KotlinSagaAssociationPropertyInspection())
+        myFixture.openFileInEditor(file)
+        val highlights = myFixture.doHighlighting(HighlightSeverity.WARNING)
+        Assertions.assertThat(highlights).noneMatch {
+            it.description.contains("The message does not declare a property")
         }
     }
 
@@ -99,7 +121,31 @@ class KotlinSagaAssociationPropertyInspectionTest : AbstractAxonFixtureTestCase(
         myFixture.openFileInEditor(file)
         val highlights = myFixture.doHighlighting(HighlightSeverity.WARNING)
         Assertions.assertThat(highlights).noneMatch {
-            it.text == "handle" && it.description.contains("The message does not declare a property")
+            it.description.contains("The message does not declare a property")
+        }
+    }
+
+    fun `test detect defined getter in superclass`() {
+        val file = addFile(
+            "file.kt", """
+                open class MyBaseMessage() {
+                   fun getSome() = ""                 
+                }
+                
+                open class MyMessage : MyBaseMessage
+                
+                class MyHandler {
+                    @SagaEventHandler(associationProperty = "some")
+                    fun handle(message: MyMessage) {}
+                }
+        """.trimIndent()
+        )
+
+        myFixture.enableInspections(KotlinSagaAssociationPropertyInspection())
+        myFixture.openFileInEditor(file)
+        val highlights = myFixture.doHighlighting(HighlightSeverity.WARNING)
+        Assertions.assertThat(highlights).noneMatch {
+            it.description.contains("The message does not declare a property")
         }
     }
 }


### PR DESCRIPTION
In our project we get warnings on SagaEventHandlers that rely on an associationProperty from a superclass of the messsage. This works in Axon but is indicated as a problem by the plugin.

This PR fixes that for the SagaEventHandlers, but there are probably other cases where this applies (routingKeys?). We do not have this case in our project at the moment, so I did not change that.

This pull request resolves #307. 