### PR TITLE
Enable support for K2 mode of the Kotlin compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Axon Framework plugin Changelog
 
+## [0.9.0]
+- Plugin is now compatible with IDEA 2024.3 (IDEA 243.*) with minimum version of 2024.3
+- Make plugin compatible with the K2 mode of IntelliJ IDEA
+
 ## [0.8.9]
 - Fix false highlights about non existing properties when they are defined in a superclass #307 Thanks to @guymahieu
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ plugins {
     // Java support
     id("java")
     // Kotlin support
-    id("org.jetbrains.kotlin.jvm") version "1.9.22"
+    id("org.jetbrains.kotlin.jvm") version "2.1.0"
     // Gradle IntelliJ Plugin
     id("org.jetbrains.intellij.platform") version "2.1.0"
     // Gradle Changelog Plugin

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,14 +18,14 @@
 # Basic plugin information
 pluginGroup=io.axoniq.ide.intellij
 pluginName=Axon Framework
-pluginVersion=0.8.9
+pluginVersion=0.9.0
 axonVersion=4.10.1
 javaVersion = 17
 
 # Define the plugin version range. This is used to determine the compatibility of the plugin with the IDE.
 pluginSinceBuild = 242
 pluginUntilBuild = 243.*
-platformVersion = 2024.2
+platformVersion = 2024.3
 
 # Opt-out flag for bundling Kotlin standard library.
 # See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -123,6 +123,10 @@
         <errorHandler implementation="org.axonframework.intellij.ide.plugin.support.AxonErrorReportSubmitter"/>
     </extensions>
 
+    <extensions defaultExtensionNs="org.jetbrains.kotlin">
+        <supportsKotlinPluginMode supportsK2="true" />
+    </extensions>
+
     <actions>
         <action id="AxonReferenceGuideAction" text="Axon Reference Guide"
                 class="org.axonframework.intellij.ide.plugin.actions.AxonReferenceGuideAction">


### PR DESCRIPTION
We are lucky. Since we use the UAST everywhere, there are no code changes needed. I tested it with several projects, especially focussing on areas that have differences between Java and Kotlin.