### PR TITLE
No longer show the routing key inspection warning when the method is …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # Axon Framework plugin Changelog
 
+## [0.9.2]
+- No longer show the routing key inspection warning when the method is not annotated with a relevant handler annotation.
+
 ## [0.9.1]
 - Disable plugin when Axon Framework 5 or greater is detected. The plugin is not compatible with Axon Framework 5 and greater at this time, as it is an experimental branch. Future versions of the plugin will be compatible with Axon Framework 5 and greater, once it approaches release readiness.
 

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/inspections/aggregate/JavaMissingRoutingKeyOnAggregateMemberInspection.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/inspections/aggregate/JavaMissingRoutingKeyOnAggregateMemberInspection.kt
@@ -48,9 +48,12 @@ class JavaMissingRoutingKeyOnAggregateMemberInspection : AbstractBaseJavaLocalIn
             ?: entity.routingKey
             ?: return null
 
-        if (method.hasAnnotation(AxonAnnotation.EVENT_SOURCING_HANDLER) &&
-            entityMember.eventForwardingMode != "org.axonframework.modelling.command.ForwardMatchingInstances"
-        ) {
+        val isEventSourcingHandler = method.hasAnnotation(AxonAnnotation.EVENT_SOURCING_HANDLER)
+        if(!isEventSourcingHandler && !method.hasAnnotation(AxonAnnotation.COMMAND_HANDLER)) {
+            return null
+        }
+
+        if (isEventSourcingHandler && entityMember.eventForwardingMode != "org.axonframework.modelling.command.ForwardMatchingInstances") {
             return null
         }
         val payload = method.resolvePayloadType() ?: return null

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/inspections/aggregate/KotlinMissingRoutingKeyOnAggregateMemberInspection.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/inspections/aggregate/KotlinMissingRoutingKeyOnAggregateMemberInspection.kt
@@ -57,9 +57,11 @@ class KotlinMissingRoutingKeyOnAggregateMemberInspection : AbstractKotlinInspect
                 val routingKey = entityMember.routingKey
                     ?: entity.routingKey
                     ?: return
-                if (method.hasAnnotation(AxonAnnotation.EVENT_SOURCING_HANDLER) &&
-                    entityMember.eventForwardingMode != "org.axonframework.modelling.command.ForwardMatchingInstances"
-                ) {
+                val isEventSourcingHandler = method.hasAnnotation(AxonAnnotation.EVENT_SOURCING_HANDLER)
+                if(!isEventSourcingHandler && !method.hasAnnotation(AxonAnnotation.COMMAND_HANDLER)) {
+                    return
+                }
+                if (isEventSourcingHandler && entityMember.eventForwardingMode != "org.axonframework.modelling.command.ForwardMatchingInstances") {
                     return
                 }
                 val payload = method.resolvePayloadType() ?: return


### PR DESCRIPTION
…not annotated with a relevant handler annotation


The lack of this check caused false positives. 