### PR TITLE
Fix false positive on versions not equal to 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # Axon Framework plugin Changelog
 
+## [0.9.2]
+- Fix false positive on versions not equal to 4
+
 ## [0.9.1]
 - Disable plugin when Axon Framework 5 or greater is detected. The plugin is not compatible with Axon Framework 5 and greater at this time, as it is an experimental branch. Future versions of the plugin will be compatible with Axon Framework 5 and greater, once it approaches release readiness.
 

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/usage/AxonDependency.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/usage/AxonDependency.kt
@@ -16,35 +16,42 @@
 
 package org.axonframework.intellij.ide.plugin.usage
 
-enum class AxonDependency(val moduleName: String, val checkVersion: Boolean = true) {
-    Core("axon-core"), // Axon 2 only
-    Integration("axon-integration"), // Axon 2 only
-    SpringMessaging("axon-springmessaging"), // Axon 2 only
-    DistributedCommandBus("axon-distributed-commandbus"), // Axon 2 only
-    Spring("axon-spring"), // Axon 3 and 4
-    SpringAutoconfigure("axon-spring-boot-autoconfigure"), // Axon 3 and 4
-    SpringStarter("axon-spring-boot-starter"), // Axon 3 and 4
-    Messaging("axon-messaging"), // Axon 4 only
-    EventSourcing("axon-eventsourcing"), // Axon 4 only
-    Modelling("axon-modelling"), // Axon 4 only
-    Configuration("axon-configuration"), // Axon 4 only
-    Test("axon-test"), // Axon 2, 3 and 4
-    Metrics("axon-metrics"), // Axon 3 and 4
-    Legacy("axon-legacy"), // Axon 3 and 4
-    Micrometer("axon-micrometer"), // Axon 4 only
-    Disruptor("axon-disruptor"), // Axon 4 only
-    ServerConnector("axon-server-connector"), // Axon 4 only
+enum class AxonDependency(
+    val groupId: String,
+    val artifactId: String,
+    val checkVersion: Boolean = true
+) {
+    Core("org.axonframework", "axon-core"), // Axon 2 only
+    Integration("org.axonframework", "axon-integration"), // Axon 2 only
+    SpringMessaging("org.axonframework", "axon-springmessaging"), // Axon 2 only
+    DistributedCommandBus("org.axonframework", "axon-distributed-commandbus"), // Axon 2 only
+    Spring("org.axonframework", "axon-spring"), // Axon 3 and 4
+    SpringAutoconfigure("org.axonframework", "axon-spring-boot-autoconfigure"), // Axon 3 and 4
+    SpringStarter("org.axonframework", "axon-spring-boot-starter"), // Axon 3 and 4
+    Messaging("org.axonframework", "axon-messaging"), // Axon 4 only
+    EventSourcing("org.axonframework", "axon-eventsourcing"), // Axon 4 only
+    Modelling("org.axonframework", "axon-modelling"), // Axon 4 only
+    Configuration("org.axonframework", "axon-configuration"), // Axon 4 only
+    Test("org.axonframework", "axon-test"), // Axon 2, 3 and 4
+    Metrics("org.axonframework", "axon-metrics"), // Axon 3 and 4
+    Legacy("org.axonframework", "axon-legacy"), // Axon 3 and 4
+    Micrometer("org.axonframework", "axon-micrometer"), // Axon 4 only
+    Disruptor("org.axonframework", "axon-disruptor"), // Axon 4 only
+    ServerConnector("org.axonframework", "axon-server-connector"), // Axon 4 only
 
     // Extensions, used for reporting during bugs, not for version check
-    Mongo("axon-mongo", false),
-    Mongo3("axon-mongo3", false),
-    Amqp("axon-amqp", false),
-    Jgroups("axon-jgroups", false),
-    Reactor("axon-reactor", false),
-    Kotlin("axon-kotlin", false),
-    Kafka("axon-kafka", false),
-    Multitenancy("axon-multitenancy", false),
-    SpringCloud("axon-springcloud", false),
-    Tracing("axon-tracing", false),
-    Cdi("axon-cdi", false),
+    Mongo("org.axonframework.extensions.mongo", "axon-mongo", false),
+    Amqp("org.axonframework", "axon-amqp", false),
+    Jgroups("org.axonframework.extensions.jgroups", "axon-jgroups", false),
+    Reactor("org.axonframework.extensions.reactor", "axon-reactor", false),
+    Kotlin("org.axonframework.extensions.kotlin", "axon-kotlin", false),
+    Kafka("org.axonframework.extensions.kafka", "axon-kafka", false),
+    Multitenancy("org.axonframework.extensions.multitenancy", "axon-multitenancy", false),
+    SpringCloud("org.axonframework.extensions.springcloud", "axon-springcloud", false),
+    Tracing("org.axonframework.extensions.tracing", "axon-tracing", false),
+    Cdi("org.axonframework.extensions.cdi", "axon-cdi", false),
+    ;
+
+    val moduleName: String
+        get() = "$groupId:$artifactId"
 }


### PR DESCRIPTION
The version check was quite primitive, checking the jar name and extracting the name from that. This made it quite unreliable, and disabled the plugin for users with their own `axon-*` module (#327).

The version check has now been changed. JARs found to contain the name axon will now be checked its META-INF for it's groupId and artifactID, and only be disabled/detected if it is the correct group.

Resolves #327