### PR TITLE
Remove build-until from plugin.xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # Axon Framework plugin Changelog
 
+## [0.9.3]
+- Remove build-until from plugin.xml, as we generally stay compatible with IDEA
+
 ## [0.9.2]
 - No longer show the routing key inspection warning when the method is not annotated with a relevant handler annotation.
 - Fix false positive on versions not equal to 4

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,7 +46,7 @@ intellijPlatform {
         version = properties("pluginVersion")
         ideaVersion {
             sinceBuild = properties("pluginSinceBuild")
-            untilBuild = properties("pluginUntilBuild")
+            untilBuild = provider { null }
         }
 
 
@@ -87,7 +87,7 @@ intellijPlatform {
                 types = listOf(IntelliJPlatformType.IntellijIdeaCommunity)
                 channels = listOf(ProductRelease.Channel.RELEASE, ProductRelease.Channel.EAP)
                 sinceBuild = properties("pluginSinceBuild")
-                untilBuild = properties("pluginUntilBuild")
+                untilBuild = provider { null }
             }
         }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,6 @@ javaVersion = 17
 
 # Define the plugin version range. This is used to determine the compatibility of the plugin with the IDE.
 pluginSinceBuild = 242
-pluginUntilBuild = 243.*
 platformVersion = 2024.3
 
 # Opt-out flag for bundling Kotlin standard library.


### PR DESCRIPTION
We generally stay compatible with IDEA, so there's no reason to break the plugin for everyone three times a years. Let's remove the end-build. Jetbrains will periodically check compatibility and email us if it no longer is.