### PR TITLE
Fix NPE in version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # Axon Framework plugin Changelog
 
+## [0.9.4]
+- Fix NPE in version check when using a malformed version string for an Axon dependency
+
 ## [0.9.3]
 - Remove build-until from plugin.xml, as we generally stay compatible with IDEA
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@
 # Basic plugin information
 pluginGroup=io.axoniq.ide.intellij
 pluginName=Axon Framework
-pluginVersion=0.9.3
+pluginVersion=0.9.4
 axonVersion=4.10.1
 javaVersion = 17
 

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/actions/ReportFeedbackAction.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/actions/ReportFeedbackAction.kt
@@ -16,6 +16,7 @@
 
 package org.axonframework.intellij.ide.plugin.actions
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.ApplicationManager
@@ -46,5 +47,9 @@ class ReportFeedbackAction : AnAction(AxonIcons.Axon) {
             }
             service.reportFeedback(e.project, feedback)
         }
+    }
+
+    override fun getActionUpdateThread(): ActionUpdateThread {
+        return ActionUpdateThread.BGT
     }
 }

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/usage/AxonVersionService.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/usage/AxonVersionService.kt
@@ -135,7 +135,6 @@ class AxonVersionService(val project: Project) {
         .productionOnly()
         .classes()
         .roots
-        .filter { it.presentableName.contains("axon") }
         .flatMap { root ->
             val jarFile = VfsUtilCore.virtualToIoFile(root)
             if (jarFile.extension == "jar") {
@@ -156,24 +155,29 @@ class AxonVersionService(val project: Project) {
         }
 
     private fun extractVersion(properties: Properties): AxonDependencyVersion? {
-        val groupId = properties.getProperty("groupId")
-        val artifactId = properties.getProperty("artifactId")
-        val version = properties.getProperty("version")
-        if(groupId.isNullOrEmpty() || artifactId.isNullOrEmpty() || version.isNullOrEmpty()) {
+        try {
+            val groupId = properties.getProperty("groupId")
+            val artifactId = properties.getProperty("artifactId")
+            val version = properties.getProperty("version")
+            if (groupId.isNullOrEmpty() || artifactId.isNullOrEmpty() || version.isNullOrEmpty()) {
+                return null
+            }
+            val dependency = AxonDependency.entries.firstOrNull { it.groupId == groupId && it.artifactId == artifactId }
+            if (dependency == null) {
+                return null
+            }
+            val (majorVersion, minorVersion, patchVersion, remaining) = versionRegex.find(version)?.destructured ?: return null
+            return AxonDependencyVersion(
+                dependency,
+                Integer.parseInt(majorVersion),
+                Integer.parseInt(minorVersion),
+                Integer.parseInt(patchVersion),
+                remaining
+            )
+        } catch (e: Exception) {
+            // Ignore
             return null
         }
-        val dependency = AxonDependency.entries.firstOrNull { it.groupId == groupId && it.artifactId == artifactId }
-        if(dependency == null) {
-            return null
-        }
-        val (majorVersion, minorVersion, patchVersion, remaining) = versionRegex.find(version)!!.destructured
-        return AxonDependencyVersion(
-            dependency,
-            Integer.parseInt(majorVersion),
-            Integer.parseInt(minorVersion),
-            Integer.parseInt(patchVersion),
-            remaining
-        )
     }
 
     data class AxonDependencyVersion(


### PR DESCRIPTION
One of our users has an axon dependency version that does not follow semantic versioning. This causes the plugin to crash. We will now ignore malformed versions for Axon dependencies, and errors will now be caught