### PR TITLE
Fix internal Kotlin plugin API breakage on IntelliJ 2026.2+

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -143,7 +143,13 @@ tasks {
 
 dependencies {
     intellijPlatform {
-        intellijIdeaCommunity(properties("platformVersion"))
+        // Set -PlocalIdePath=/path/to/ide to test/run against a local IDE installation
+        // instead of downloading the version pinned in gradle.properties.
+        if (project.hasProperty("localIdePath")) {
+            local(file(properties("localIdePath")))
+        } else {
+            intellijIdeaCommunity(properties("platformVersion"))
+        }
         bundledPlugin("com.intellij.java")
         bundledPlugin("org.jetbrains.kotlin")
         pluginVerifier()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -88,7 +88,7 @@ intellijPlatform {
                 types = listOf(IntelliJPlatformType.IntellijIdeaCommunity)
                 channels = listOf(ProductRelease.Channel.RELEASE)
                 sinceBuild = properties("pluginSinceBuild")
-                untilBuild = "252.*"
+                untilBuild = "262.*"
             }
         }
 

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/inspections/aggregate/KotlinAggregateMemberRoutingKeyInspection.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/inspections/aggregate/KotlinAggregateMemberRoutingKeyInspection.kt
@@ -23,9 +23,10 @@ import com.intellij.psi.PsiElementVisitor
 import org.axonframework.intellij.ide.plugin.util.aggregateResolver
 import org.axonframework.intellij.ide.plugin.util.isAxon4Project
 import org.jetbrains.kotlin.idea.codeinsight.api.classic.inspections.AbstractKotlinInspection
-import org.jetbrains.kotlin.idea.refactoring.memberInfo.qualifiedClassNameForRendering
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.uast.UClass
+import org.jetbrains.uast.toUElementOfType
 
 
 /**
@@ -44,7 +45,8 @@ class KotlinAggregateMemberRoutingKeyInspection : AbstractKotlinInspection() {
                 if (!element.project.isAxon4Project()) {
                     return
                 }
-                val entity = element.aggregateResolver().getEntityByName(element.qualifiedClassNameForRendering()) ?: return
+                val uClass = element.toUElementOfType<UClass>() ?: return
+                val entity = uClass.qualifiedName?.let { uClass.aggregateResolver().getEntityByName(it) } ?: return
                 entity.members.filter { it.isCollection && it.member.routingKey == null }.map { child ->
                     val ktField = element.declarations.filterIsInstance<KtProperty>().first { it.name == child.fieldName }
                     holder.registerProblem(

--- a/src/main/kotlin/org/axonframework/intellij/ide/plugin/inspections/saga/KotlinSagaAssociationPropertyInspection.kt
+++ b/src/main/kotlin/org/axonframework/intellij/ide/plugin/inspections/saga/KotlinSagaAssociationPropertyInspection.kt
@@ -29,7 +29,6 @@ import org.axonframework.intellij.ide.plugin.util.resolveAnnotationStringValue
 import org.axonframework.intellij.ide.plugin.util.resolveAnnotationValue
 import org.axonframework.intellij.ide.plugin.util.resolvePayloadType
 import org.axonframework.intellij.ide.plugin.util.toClass
-import org.jetbrains.kotlin.asJava.elements.KtLightPsiLiteral
 import org.jetbrains.kotlin.idea.codeinsight.api.classic.inspections.AbstractKotlinInspection
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.uast.UMethod
@@ -68,9 +67,9 @@ class KotlinSagaAssociationPropertyInspection : AbstractKotlinInspection() {
                     return
                 }
                 val annotation = method.resolveAnnotation(AxonAnnotation.SAGA_EVENT_HANDLER) ?: return
-                val property = annotation.findAttributeValue("associationProperty") as KtLightPsiLiteral? ?: return
+                val property = annotation.findAttributeValue("associationProperty") ?: return
                 holder.registerProblem(
-                    property.kotlinOrigin,
+                    property.navigationElement,
                     associationPropertyDescription,
                     ProblemHighlightType.WARNING,
                     null as TextRange?,


### PR DESCRIPTION
## Summary

Two Kotlin-specific inspections relied on internal/unstable `org.jetbrains.kotlin.idea.*` and `org.jetbrains.kotlin.asJava.*` classes that got relocated or removed in the IntelliJ 2026.2 Kotlin plugin (build 262.8665.337). On that IDE version, opening a file that triggers either inspection throws `NoClassDefFoundError`/`ClassNotFoundException`, crashing the highlighting pass.

- `KotlinAggregateMemberRoutingKeyInspection`: replaced `org.jetbrains.kotlin.idea.refactoring.memberInfo.qualifiedClassNameForRendering()` with UAST's `UClass.qualifiedName`, matching the existing pattern already used in `KotlinAggregateIdInspection`.
- `KotlinSagaAssociationPropertyInspection`: replaced the cast to `KtLightPsiLiteral` + `.kotlinOrigin` with `PsiElement.navigationElement` — the light-element base class that backed `KtLightPsiLiteral` already overrides this stable, cross-language PSI method for exactly this purpose.
- Added an opt-in `-PlocalIdePath=/path/to/ide` Gradle property so contributors can compile/run/test against a locally installed IDE instead of the pinned `platformVersion`, to catch this class of issue going forward without needing to bump the project's platform pin.
- Raised the `pluginVerification` `untilBuild` range from `252.*` (2025.2) to `262.*` (2026.2) to cover the latest IntelliJ version. The old cap meant CI's `verifyPlugin` task — which does static bytecode-level API-compatibility checks — never actually checked compatibility against 2025.3/2026.x builds, even though `plugin.xml` declares no upper bound. That gap is exactly why this breakage went unnoticed; the verifier would very likely have flagged both removed symbols had it been checking these builds.

## Test plan

- [x] Full test suite passes (159 tests: 140 v4, 19 v5)
- [x] Compiles cleanly against the pinned `platformVersion` (2024.3) and against IntelliJ 2026.2 (build 262.8665.337) via `-PlocalIdePath`
- [x] Manually reproduced the original crash by installing a built plugin into a real IntelliJ 2026.2.0.1 instance with the unfixed code, then confirmed both crashes are resolved after installing the fixed build
- [x] CI's `verifyPlugin` task now runs against the extended IDE range on this PR

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>